### PR TITLE
Fix conf.py to not have 'copyright' twice.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -93,7 +93,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Fedora Messaging'
-copyright = u'Copyright © 2012 Red Hat, Inc. and others.'
+copyright = u'2012 Red Hat, Inc. and others.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
In the documentation, the footer was getting generated as:

```
 © Copyright Copyright © 2012 Red Hat, Inc. and others.. Created using Sphinx 1.1.3.
```

And should now get generated as:

```
 © Copyright 2012 Red Hat, Inc. and others.. Created using Sphinx 1.1.3.
```
