### PR TITLE
Return empty strings from our text processors instead of raising exceptions.

### DIFF
--- a/fedmsg/text/bodhi.py
+++ b/fedmsg/text/bodhi.py
@@ -117,5 +117,3 @@ class BodhiProcessor(BaseProcessor):
             return tmpl.format(title=msg['msg']['update']['title'])
         elif 'bodhi.update.request' in msg['topic']:
             return tmpl.format(title=msg['msg']['update']['title'])
-        else:
-            raise NotImplementedError

--- a/fedmsg/text/mediawiki.py
+++ b/fedmsg/text/mediawiki.py
@@ -43,14 +43,10 @@ class WikiProcessor(BaseProcessor):
             )
             return tmpl.format(user=user, filename=filename,
                                description=description)
-        else:
-            raise NotImplementedError
 
     def link(self, msg, **config):
         if 'wiki.article.edit' in msg['topic']:
             return msg['msg']['url']
-        else:
-            raise NotImplementedError
 
     def icon(self, msg, **config):
         return "https://fedoraproject.org/w/skins/common/images/mediawiki.png"

--- a/fedmsg/text/scm.py
+++ b/fedmsg/text/scm.py
@@ -91,8 +91,6 @@ class SCMProcessor(BaseProcessor):
                     'run of pkgdb2branch started by {agent} completed' +
                     ' with %i errors'
                 ) % errors
-        else:
-            raise NotImplementedError
 
         agent = msg['msg']['agent']
         return tmpl.format(agent=agent)
@@ -119,5 +117,3 @@ class SCMProcessor(BaseProcessor):
             tmpl = "{prefix}/{name}/{filename}/{md5sum}/{filename}"
             return tmpl.format(prefix=prefix, name=name,
                                md5sum=md5sum, filename=filename)
-        else:
-            raise NotImplementedError


### PR DESCRIPTION
Certain messages don't have links, icons, etc. Instead of raising NotImplementedError, we should probably just return None.
