### PR TITLE
Fix validate signatures

### DIFF
--- a/fedmsg/consumers/__init__.py
+++ b/fedmsg/consumers/__init__.py
@@ -81,7 +81,8 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
         # This call "completes" registration of this consumer with the hub.
         super(FedmsgConsumer, self).__init__(hub)
 
-        self.validate_signatures = self.hub.config['validate_signatures']
+        if self.validate_signatures:
+            self.validate_signatures = self.hub.config['validate_signatures']
 
     def validate(self, message):
         """ This needs to raise an exception, caught by moksha. """


### PR DESCRIPTION
This would raise an exception if you didn't provide signatures and then the rest of the constructors wouldn't be finalized and things like SQLAlchemy wouldn't be bound
