### PR TITLE
Allow commands to be tested

### DIFF
--- a/fedmsg/commands/__init__.py
+++ b/fedmsg/commands/__init__.py
@@ -22,6 +22,7 @@ import fedmsg.config
 import warnings
 import logging
 
+
 class command(object):
     """ Convenience decorator for wrapping fedmsg console script commands.
 


### PR DESCRIPTION
For testing purposes, the commands decorator should track its wrapped function.  That way when you are testing you can do something similar to:

mycommand.**wrapped_func**(_args, *_kwargs)
