### PR TITLE
"version is required for logging config"

### DIFF
--- a/fedmsg/commands/__init__.py
+++ b/fedmsg/commands/__init__.py
@@ -50,7 +50,7 @@ class BaseCommand(object):
             )
 
         self.config = self.get_config()
-        dictConfig(self.config.get('logging', {}))
+        dictConfig(self.config.get('logging', {'version': 1}))
         self.log = logging.getLogger("fedmsg")
 
     def get_config(self):


### PR DESCRIPTION
bug fix. Messages were not being added to datanommer database. According to http://docs.python.org/2/library/logging.config.html ::

The dictionary passed to dictConfig() must contain the following keys:

version - to be set to an integer value representing the schema version. The only valid value at present is 1, but having this key allows the schema to evolve while still preserving backwards compatibility.
