### PR TITLE
Fix typo in the docstring for make_processors

### DIFF
--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -83,7 +83,7 @@ def make_processors(**config):
         >>> import fedmsg.meta
         >>> config = fedmsg.config.load_config([], None)
         >>> fedmsg.meta.make_processors(**config)
-        >>> text = fedmsg.meta.msgrepr(some_message_dict, **config)
+        >>> text = fedmsg.meta.msg2repr(some_message_dict, **config)
 
     """
     global processors


### PR DESCRIPTION
Fix typo in the docstring ( missing 2, so code cannot be cut and paste )
