### PR TITLE
Split the crypto module out into two backends.

### DIFF
--- a/fedmsg/crypto/__init__.py
+++ b/fedmsg/crypto/__init__.py
@@ -1,0 +1,207 @@
+# This file is part of fedmsg.
+# Copyright (C) 2012 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Ralph Bean <rbean@redhat.com>
+#
+""" ``fedmsg.crypto`` - Cryptographic component of fedmsg.
+
+Introduction
+------------
+
+In general, we assume that 'everything on the bus is public'.  Even though all
+the zmq endpoints are firewalled off from the outside world with iptables, we
+do have a forwarding service setup that indiscriminantly
+forwards all messages to anyone who wants them.
+(See :mod:`fedmsg.commands.gateway.gateway` for that service.)
+So, the issue is not encrypting messages so they can't be read.  It is up to
+sensitive services like FAS to *not send* sensitive information in the first
+place (like passwords, for instance).
+
+However, since at some point, services will respond to and act on messages that
+come across the bus, we need facilities for guaranteeing a message comes from
+where it *ought* to come from.  (Tangentially, message consumers need a simple
+way to declare where they expect their messages to come from and have
+the filtering and validation handled for them).
+
+There should also be a convenient way to turn crypto off both globally and
+locally.  Justification: a developer may want to work out a bug without any
+messages being signed or validated.  In production, certain senders may send
+non-critical data from a corner of Fedora Infrastructure in which it's
+difficult to sign messages.  A consumer of those messages should be allowed
+to ignore validation for those and only those expected unsigned messages
+
+Two backend methods are available to accomplish this:
+
+    - :mod:`fedmsg.crypto.x509`
+    - :mod:`fedmsg.crypto.gpg`
+
+Which backend is used is configured by the :term:`crypto_backend` configuration
+value.
+
+Certificates
+------------
+
+To accomplish message signing, fedmsg must be able to read certificates and a
+private key on disk in the case of the :mod:`fedmsg.crypto.x509` backend
+or to read public and private GnuPG keys in the came of the
+:mod:`fedmsg.crypto.gpg` backend.  For message validation, it only need be
+able to read the x509 certificate or gpg public key.  Exactly *which*
+certificates are used are determined by looking up the ``certname`` in the
+:term:`certnames` config dict.
+
+We use a large number of certs for the deployment of fedmsg.  We have one cert
+per `service-host`.  For example, if we have 3 fedmsg-enabled services and each
+service runs on 10 hosts, then we have 30 unique certificate/key pairs in all.
+
+The intent is to create difficulty for attackers.  If a low-security service on
+a particular box is compromised, we don't want the attacker automatically have
+access to the same certificate used for signing high-security service messages.
+
+Furthermore, attempts are made at the sysadmin-level to ensure that
+fedmsg-enabled services run as users that have exclusive read access to their
+own keys.  See the `Fedora Infrastructure SOP
+<http://infrastructure.fedoraproject.org/infra/docs/fedmsg-certs.txt>`_ for
+more information (including how to generate new certs/bring up new services).
+
+Routing Policy
+--------------
+
+Messages are also checked to see if the name of the certificate they bear and
+the topic they're routed on match up in a :term:`routing_policy` dict.  Is the
+build server allowed to send messages about wiki updates?  Not if the routing
+policy has anything to say about it.
+
+.. note::  By analogy, "signature validation is to authentication as
+           routing policy checks are to authorization."
+
+If the topic of a message appears in the :term:`routing_policy`, the name borne
+on the certificate must also appear under the associated list of permitted
+publishers or the message is marked invalid.
+
+If the topic of a message does *not* appear in the :term:`routing_policy`, two
+different courses of action are possible:
+
+    - If :term:`routing_nitpicky` is set to ``False``, then the message is
+      given the green light.  Our routing policy doesn't have anything
+      specific to say about messages of this topic and so who are we to deny
+      it passage, right?
+    - If :term:`routing_nitpicky` is set to ``True``, then we deny the message
+      and mark it as invalid.
+
+Typically, you'll deploy fedmsg with nitpicky mode turned off.  You can build
+your policy over time as you determine what services will be sending what
+messages.  Once deployment of fedmsg reaches a certain level of stability, you
+can turn nitpicky mode on for enhanced security, but by doing so you may break
+certain message paths that you've forgotten to include in your routing policy.
+
+Configuration
+-------------
+
+By convention, configuration values for :mod:`fedmsg.crypto` are kept in
+``/etc/fedmsg.d/ssl.py``, although technically they can be kept in any
+config ``dict`` in ``/etc/fedmsg.d`` (or in any of the config locations checked
+by :mod:`fedmsg.config`).
+
+The cryptography routines expect the following values to be defined:
+
+  - :term:`crypto_backend`
+  - :term:`sign_messages`
+  - :term:`validate_signatures`
+  - :term:`ssldir`
+  - :term:`crl_location`
+  - :term:`crl_cache`
+  - :term:`crl_cache_expiry`
+  - :term:`certnames`
+  - :term:`routing_policy`
+  - :term:`routing_nitpicky`
+
+For general information on configuration, see :mod:`fedmsg.config`.
+
+Module Contents
+---------------
+
+:mod:`fedmsg.crypto` encapsulates standalone functions for:
+
+    - Message signing.
+    - Signature validation.
+    - Stripping crypto information for view.
+
+See :mod:`fedmsg.crypto.x509` and :mod:`fedmsg.crypto.gpg` for
+implementation details.
+
+"""
+
+import copy
+
+_implementation = None
+
+
+def init(**config):
+    """ Initialize the crypto backend.
+
+    The backend can be one of two plugins:
+
+        - 'x509' - Uses x509 certificates.
+        - 'gpg' - Uses GnuPG keys.
+    """
+    global _implementation
+
+    if config.get('crypto_backend') == 'gpg':
+        import gpg
+        _implementation = gpg
+    else:
+        import x509
+        _implementation = x509
+
+
+def sign(message, ssldir, certname, **config):
+    """ Insert two new fields into the message dict and return it.
+
+    Those fields are:
+
+        - 'signature' - the computed message digest of the JSON repr.
+        - 'certificate' - the base64 certificate or gpg key of the signator.
+    """
+
+    if not _implementation:
+        init(ssldir=ssldir, certname=certname, **config)
+
+    return _implementation.sign(message, ssldir, certname, **config)
+
+
+def validate(message, ssldir, **config):
+    """ Return true or false if the message is signed appropriately. """
+
+    if not _implementation:
+        init(ssldir=ssldir, **config)
+
+    return _implementation.validate(message, ssldir, **config)
+
+
+def strip_credentials(message):
+    """ Strip credentials from a message dict.
+
+    A new dict is returned without either `signature` or `certificate` keys.
+    This method can be called safely; the original dict is not modified.
+
+    This function is applicable using either using the x509 or gpg backends.
+    """
+    message = copy.deepcopy(message)
+    for field in ['signature', 'certificate']:
+        if field in message:
+            del message[field]
+    return message

--- a/fedmsg/crypto/gpg.py
+++ b/fedmsg/crypto/gpg.py
@@ -1,0 +1,28 @@
+# This file is part of fedmsg.
+# Copyright (C) 2012 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Ralph Bean <rbean@redhat.com>
+#
+""" ``fedmsg.crypto.gpg`` - GnuPG backend for :mod:`fedmsg.crypto` """
+
+
+def sign(message, ssldir, certname, **config):
+    raise NotImplementedError("Coming soon!")
+
+
+def validate(message, ssldir, **config):
+    raise NotImplementedError("Coming soon!")

--- a/fedmsg/crypto/x509.py
+++ b/fedmsg/crypto/x509.py
@@ -17,128 +17,14 @@
 #
 # Authors:  Ralph Bean <rbean@redhat.com>
 #
-""" ``fedmsg.crypto`` - Cryptographic component of fedmsg.
-
-Introduction
-------------
-
-In general, we assume that 'everything on the bus is public'.  Even though all
-the zmq endpoints are firewalled off from the outside world with iptables, we
-do have a forwarding service setup that indiscriminantly
-forwards all messages to anyone who wants them.
-(See :mod:`fedmsg.commands.gateway.gateway` for that service.)
-So, the issue is not encrypting messages so they can't be read.  It is up to
-sensitive services like FAS to *not send* sensitive information in the first
-place (like passwords, for instance).
-
-However, since at some point, services will respond to and act on messages that
-come across the bus, we need facilities for guaranteeing a message comes from
-where it *ought* to come from.  (Tangentially, message consumers need a simple
-way to declare where they expect their messages to come from and have
-the filtering and validation handled for them).
-
-There should also be a convenient way to turn crypto off both globally and
-locally.  Justification: a developer may want to work out a bug without any
-messages being signed or validated.  In production, certain senders may send
-non-critical data from a corner of Fedora Infrastructure in which it's
-difficult to sign messages.  A consumer of those messages should be allowed
-to ignore validation for those and only those expected unsigned messages
-
-Certificates
-------------
-
-To accomplish message signing, fedmsg must be able to read certificates and a
-private key on disk.  For message validation, it only need be able to read the
-certificate.  Exactly *which* certificates are used are determined by looking
-up the ``certname`` in the :term:`certnames` config dict.
-
-We use a large number of certs for the deployment of fedmsg.  We have one cert
-per `service-host`.  For example, if we have 3 fedmsg-enabled services and each
-service runs on 10 hosts, then we have 30 unique certificate/key pairs in all.
-
-The intent is to create difficulty for attackers.  If a low-security service on
-a particular box is compromised, we don't want the attacker automatically have
-access to the same certificate used for signing high-security service messages.
-
-Furthermore, attempts are made at the sysadmin-level to ensure that
-fedmsg-enabled services run as users that have exclusive read access to their
-own keys.  See the `Fedora Infrastructure SOP
-<http://infrastructure.fedoraproject.org/infra/docs/fedmsg-certs.txt>`_ for
-more information (including how to generate new certs/bring up new services).
-
-Routing Policy
---------------
-
-Messages are also checked to see if the name of the certificate they bear and
-the topic they're routed on match up in a :term:`routing_policy` dict.  Is the
-build server allowed to send messages about wiki updates?  Not if the routing
-policy has anything to say about it.
-
-.. note::  By analogy, "signature validation is to authentication as
-           routing policy checks are to authorization."
-
-If the topic of a message appears in the :term:`routing_policy`, the name born
-on the certificate must also appear under the associated list of permitted
-publishers or the message is marked invalid.
-
-If the topic of a message does *not* appear in the :term:`routing_policy`, two
-different courses of action are possible:
-
-    - If :term:`routing_nitpicky` is set to ``False``, then the message is
-      given the green light.  Our routing policy doesn't have anything
-      specific to say about messages of this topic and so who are we to deny
-      it passage, right?
-    - If :term:`routing_nitpicky` is set to ``True``, then we deny the message
-      and mark it as invalid.
-
-Typically, you'll deploy fedmsg with nitpicky mode turned off.  You can build
-your policy over time as you determine what services will be sending what
-messages.  Once deployment of fedmsg reaches a certain level of stability, you
-can turn nitpicky mode on for enhanced security, but by doing so you may break
-certain message paths that you've forgotten to include in your routing policy.
-
-Configuration
--------------
-
-By convention, configuration values for :mod:`fedmsg.crypto` are kept in
-``/etc/fedmsg.d/ssl.py``, although technically they can be kept in any
-config ``dict`` in ``/etc/fedmsg.d`` (or in any of the config locations checked
-by :mod:`fedmsg.config`).
-
-The cryptography routines expect the following values to be defined:
-
-  - :term:`sign_messages`
-  - :term:`validate_signatures`
-  - :term:`ssldir`
-  - :term:`crl_location`
-  - :term:`crl_cache`
-  - :term:`crl_cache_expiry`
-  - :term:`certnames`
-  - :term:`routing_policy`
-  - :term:`routing_nitpicky`
-
-For general information on configuration, see :mod:`fedmsg.config`.
-
-Module Contents
----------------
-
-:mod:`fedmsg.crypto` encapsulates standalone functions for:
-
-    - Message signing.
-    - Signature validation.
-    - Stripping crypto information for view.
-
-It also contains some hidden/private machinery to handle refreshing a cached
-CRL.
-
-"""
+""" ``fedmsg.crypto.x509`` - X.509 backend for :mod:`fedmsg.crypto`.  """
 
 
-import copy
 import os
 import requests
 import time
 
+import fedmsg.crypto
 import fedmsg.encoding
 
 import logging
@@ -211,7 +97,7 @@ def validate(message, ssldir, **config):
     decode = lambda obj: obj.decode('base64')
     signature, certificate = map(decode, (
         message['signature'], message['certificate']))
-    message = strip_credentials(message)
+    message = fedmsg.crypto.strip_credentials(message)
 
     # Build an X509 object
     cert = M2Crypto.X509.load_cert_string(certificate)
@@ -220,8 +106,9 @@ def validate(message, ssldir, **config):
     #   validate_certificate will one day be a part of M2Crypto.SSL.Context
     #   https://bugzilla.osafoundation.org/show_bug.cgi?id=11690
 
+    default_ca_cert_loc = 'https://fedoraproject.org/fedmsg/ca.crt'
     cafile = _load_remote_cert(
-        config.get('ca_cert_location', 'https://fedoraproject.org/fedmsg/ca.crt'),
+        config.get('ca_cert_location', default_ca_cert_loc),
         config.get('ca_cert_cache', '/etc/pki/fedmsg/ca.crt'),
         config.get('ca_cert_cache_expiry', 0),
         **config)
@@ -310,19 +197,6 @@ def validate(message, ssldir, **config):
             pass
 
     return True
-
-
-def strip_credentials(message):
-    """ Strip credentials from a message dict.
-
-    A new dict is returned without either `signature` or `certificate` keys.
-    This method can be called safely; the original dict is not modified.
-    """
-    message = copy.deepcopy(message)
-    for field in ['signature', 'certificate']:
-        if field in message:
-            del message[field]
-    return message
 
 
 def _load_remote_cert(location, cache, cache_expiry, **config):

--- a/fedmsg/tests/test_crypto_gpg.py
+++ b/fedmsg/tests/test_crypto_gpg.py
@@ -19,54 +19,35 @@
 #
 import os
 
-try:
-    # For python-2.6, so we can do skipTest
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+from nose.tools import raises
+import unittest
 
 import fedmsg.crypto
 
 SEP = os.path.sep
 here = SEP.join(__file__.split(SEP)[:-1])
 
-def skip_if_missing_libs(f):
-    def _wrapper(self, *args, **kw):
-        try:
-            import M2Crypto
-            import m2ext
-        except ImportError, e:
-            self.skipTest(str(e))
 
-        return f(self, *args, **kw)
-
-    return _wrapper
-
-class TestCrypto(unittest.TestCase):
+class TestCryptoGPG(unittest.TestCase):
 
     def setUp(self):
         self.config = {
-            # Normally this is /var/lib/puppet/ssl
-            'ssldir': SEP.join((here, 'test_certs/keys')),
-            # Normally this is 'app01.stg.phx2.fedoraproject.org'
-            'certname': 'shell-app01.phx2.fedoraproject.org',
-            'crl_location': "http://threebean.org/fedmsg-tests/crl.pem",
-            'crl_cache': "/tmp/crl.pem",
-            'crl_cache_expiry': 10,
-
+            'crypto_backend': 'gpg',
+            'ssldir': SEP.join((here, 'test_certs/keys_gpg')),
+            'certname': 'TODO -- fill me in.'
         }
 
     def tearDown(self):
         self.config = None
 
-    @skip_if_missing_libs
+    @raises(NotImplementedError)
     def test_full_circle(self):
         """ Try to sign and validate a message. """
         message = dict(msg='awesome')
         signed = fedmsg.crypto.sign(message, **self.config)
         assert fedmsg.crypto.validate(signed, **self.config)
 
-    @skip_if_missing_libs
+    @raises(NotImplementedError)
     def test_failed_validation(self):
         message = dict(msg='awesome')
         signed = fedmsg.crypto.sign(message, **self.config)

--- a/fedmsg/tests/test_crypto_x509.py
+++ b/fedmsg/tests/test_crypto_x509.py
@@ -1,0 +1,79 @@
+# This file is part of fedmsg.
+# Copyright (C) 2012 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Ralph Bean <rbean@redhat.com>
+#
+import os
+
+try:
+    # For python-2.6, so we can do skipTest
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import fedmsg.crypto
+
+SEP = os.path.sep
+here = SEP.join(__file__.split(SEP)[:-1])
+
+def skip_if_missing_libs(f):
+    def _wrapper(self, *args, **kw):
+        try:
+            import M2Crypto
+            import m2ext
+        except ImportError, e:
+            self.skipTest(str(e))
+
+        return f(self, *args, **kw)
+
+    return _wrapper
+
+class TestCryptoX509(unittest.TestCase):
+
+    def setUp(self):
+        self.config = {
+            # Normally this is /var/lib/puppet/ssl
+            'ssldir': SEP.join((here, 'test_certs/keys')),
+            # Normally this is 'app01.stg.phx2.fedoraproject.org'
+            'certname': 'shell-app01.phx2.fedoraproject.org',
+            'crl_location': "http://threebean.org/fedmsg-tests/crl.pem",
+            'crl_cache': "/tmp/crl.pem",
+            'crl_cache_expiry': 10,
+
+        }
+
+    def tearDown(self):
+        self.config = None
+
+    @skip_if_missing_libs
+    def test_full_circle(self):
+        """ Try to sign and validate a message. """
+        message = dict(msg='awesome')
+        signed = fedmsg.crypto.sign(message, **self.config)
+        assert fedmsg.crypto.validate(signed, **self.config)
+
+    @skip_if_missing_libs
+    def test_failed_validation(self):
+        message = dict(msg='awesome')
+        signed = fedmsg.crypto.sign(message, **self.config)
+        # space aliens read data off the wire and inject incorrect data
+        signed['msg'] = "eve wuz here"
+        assert not fedmsg.crypto.validate(signed, **self.config)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- One for X.509
- One for GnuPG (as yet unimplemented)

For consideration by @laarmen.
