### PR TITLE
ircbot: Use notices instead of actual messages

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -308,6 +308,10 @@ Glossary of Configuration Values
           ...     "planet": "light green",
           ... }
 
+    irc_method
+        ``str`` — the name of the method used to publish the messages on IRC.
+        Valid values are 'msg' and 'notice', the latter being the default.
+
     tweet_endpoints
         ``list`` - A list of twitter/statusnet configuration dicts.  This is the
         primary way of configuring the ``fedmsg-tweet`` bot implemented in

--- a/fedmsg.d/ircbot.py
+++ b/fedmsg.d/ircbot.py
@@ -45,4 +45,5 @@ config = dict(
         "buildsys": "yellow",
         "planet": "light green",
     },
+    irc_method='notice', # Either 'msg' or 'notice'
 )

--- a/fedmsg/consumers/ircbot.py
+++ b/fedmsg/consumers/ircbot.py
@@ -280,7 +280,7 @@ class IRCBotConsumer(FedmsgConsumer):
                     terse=client.factory.terse,
                 )
                 raw_msg = raw_msg.encode('utf-8')
-                client.notice(
+                getattr(client, self.hub.config['irc_method'], 'notice')(
                     client.factory.channel,
                     raw_msg,
                 )


### PR DESCRIPTION
This way, people don't get highlighted when, for instance, they upload a
new package while monitoring the channel.
