### PR TITLE
meta: test more strictly the result of handle_msg

### DIFF
--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -107,7 +107,7 @@ def msg2processor(msg, **config):
     :func:`fedmsg.meta.make_processors` hasn't been called yet.
     """
     for processor in processors:
-        if processor.handle_msg(msg, **config):
+        if processor.handle_msg(msg, **config) is not None:
             return processor
     else:
         return processors[-1]  # DefaultProcessor


### PR DESCRIPTION
In fedmsg-meta-debian, we have a processor that uses the whole topic as **name**, which means handle_msg returns an empty string, evaluating to False.
