### PR TITLE
Fix fork me github ribbon (#130)

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,9 +1,0 @@
-{% extends "basic/layout.html" %}
-{% block footer -%}
-{{ super() }}
-<a href="http://github.com/fedora-infra/fedmsg">
-  <img style="position: absolute; top: 0; right: 0; border: 0;"
-  src="https://a248.e.akamai.net/camo.github.com/7afbc8b248c68eb468279e8c17986ad46549fb71/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
-  alt="Fork me on GitHub">
-</a>
-{%- endblock %}

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -1,0 +1,9 @@
+{% extends "!page.html" %}
+{% block footer -%}
+{{ super() }}
+<a href="http://github.com/fedora-infra/fedmsg">
+  <img style="position: absolute; top: 0; right: 0; border: 0;"
+  src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"
+  alt="Fork me on GitHub">
+</a>
+{%- endblock %}


### PR DESCRIPTION
After a wild search (thanks to my google-fu) and extensive testing on rtfd.org, here is a "dirty" fix. It turns out rtfd.org is overriding the `layout.html` as you can read in https://github.com/rtfd/readthedocs.org/issues/152. You can see the results of my testing branch [here](http://fedmsg2.readthedocs.org/en/latest/index.html). I also changed the url of the png to be more human readable.

PS. In order to build the docs on rtfd.org I had to add in requirements: `nose`, `cloud_sptheme` and `fedmsg_meta_fedora_infrastructure`. On my machine (using virtualenv), I had to install those three and also `twitter`, `twitterapi` otherwise it would stop building with an error. This isn't documented anywhere, I wonder if this is just me.
