### PR TITLE
Temp fix of forkme button width on rtfd.org

### DIFF
--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -2,7 +2,7 @@
 {% block footer -%}
 {{ super() }}
 <a href="http://github.com/fedora-infra/fedmsg">
-  <img style="position: absolute; top: 0; right: 0; border: 0;"
+  <img style="position: absolute; top: 0; right: 0; border: 0; max-width: 149px;"
   src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"
   alt="Fork me on GitHub">
 </a>


### PR DESCRIPTION
After the merge of #203, I noticed that the github ribbon on rtfd.org has a weird behavior when the width of the page is less than 768px. I guess it has to do sth with the media queries of the theme we are using, but I am not so familiar in order to fix it within the css. This PR is a temp fix, setting `max-width: 149px` inline the img source. 
## Before

![forkme_wrong](https://f.cloud.github.com/assets/340023/1612933/b175957c-55cd-11e3-9518-69da7db81cc1.png)
## After

![forkme_fix](https://f.cloud.github.com/assets/340023/1612932/b05f6afa-55cd-11e3-8cf3-b62d0626e8fe.png)
