### PR TITLE
Protect against NotImplementedError.

### DIFF
--- a/fedmsg/commands/tail.py
+++ b/fedmsg/commands/tail.py
@@ -227,13 +227,15 @@ class TailCommand(BaseCommand):
             if not inclusive_regexp.search(topic):
                 continue
 
-            actual_users = fedmsg.meta.msg2usernames(message, **self.config)
-            if users and not users.intersection(actual_users):
-                continue
+            if users:
+                actual = fedmsg.meta.msg2usernames(message, **self.config)
+                if not users.intersection(actual):
+                    continue
 
-            actual_packages = fedmsg.meta.msg2packages(message, **self.config)
-            if packages and not packages.intersection(actual_packages):
-                continue
+            if packages:
+                actual = fedmsg.meta.msg2packages(message, **self.config)
+                if not packages.intersection(actual):
+                    continue
 
             self.log.info(formatter(message))
 


### PR DESCRIPTION
In fedmsg-tail, we attempt to extract the relevant usernames and
packages from a message in order to compare them against a list of
usernames or packages that the caller has requested.  However, it is
almost never the case that the caller is requesting such a thing.

This will 1) save time on average and 2) protect the caller in the case
where there is a NotImplementedError coming from one of the message
processors.
