### PR TITLE
Handle dates too.

### DIFF
--- a/fedmsg/encoding/__init__.py
+++ b/fedmsg/encoding/__init__.py
@@ -65,7 +65,7 @@ class FedMsgEncoder(json.encoder.JSONEncoder):
     def default(self, obj):
         if hasattr(obj, '__json__'):
             return obj.__json__()
-        if isinstance(obj, datetime.datetime):
+        if isinstance(obj, (datetime.datetime, datetime.date)):
             return time.mktime(obj.timetuple())
         if isinstance(obj, time.struct_time):
             return time.mktime(obj)


### PR DESCRIPTION
fedmsg.encoding can handle encoding datetime objects and time structs.

This allows it to handle datetime.date objects too.
