### PR TITLE
Add API func to validate that message bears a particular sig

### DIFF
--- a/fedmsg/crypto/__init__.py
+++ b/fedmsg/crypto/__init__.py
@@ -248,6 +248,21 @@ def validate(message, **config):
         return False
 
 
+def validate_signed_by(message, signer, **config):
+    """ Validate that a message was signed by a particular certificate.
+
+    This works much like ``validate(...)``, but additionally accepts a
+    ``signer`` argument.  It will reject a message for any of the regular
+    circumstances, but will also reject it if its not signed by a cert with the
+    argued name.
+    """
+
+    config = copy.deepcopy(config)
+    config['routing_nitpicky'] = True
+    config['routing_policy'] = {message['topic']: [signer]}
+    return validate(message, **config)
+
+
 def strip_credentials(message):
     """ Strip credentials from a message dict.
 

--- a/fedmsg/tests/test_crypto_x509.py
+++ b/fedmsg/tests/test_crypto_x509.py
@@ -98,6 +98,24 @@ class TestCryptoX509(unittest.TestCase):
         signed['msg'] = "eve wuz here"
         assert not fedmsg.crypto.validate(signed, **self.config)
 
+    @skip_if_missing_libs
+    def test_signed_by_true(self):
+        """ Try to succeed at specific-signer validation. """
+        message = dict(topic='biz.bar', msg='awesome')
+        signed = fedmsg.crypto.sign(message, **self.config)
+        signer = "shell-app01.phx2.fedoraproject.org"
+        res = fedmsg.crypto.validate_signed_by(signed, signer, **self.config)
+        assert res
+
+    @skip_if_missing_libs
+    def test_signed_by_false(self):
+        """ Try to fail at specific-signer validation. """
+        message = dict(topic='biz.bar', msg='awesome')
+        signed = fedmsg.crypto.sign(message, **self.config)
+        signer = "shell-app02.phx2.fedoraproject.org"
+        res = fedmsg.crypto.validate_signed_by(signed, signer, **self.config)
+        assert not res
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
@lmacken mentioned he was interested in using something like this for the bodhi masher.

Fixes #200.
