### PR TITLE
Be explicit with encodings in the gateway.

### DIFF
--- a/fedmsg/consumers/gateway.py
+++ b/fedmsg/consumers/gateway.py
@@ -85,4 +85,7 @@ class GatewayConsumer(FedmsgConsumer):
 
     def consume(self, msg):
         self.log.debug("Gateway: %r" % msg.topic)
-        self.gateway_socket.send_multipart([msg.topic, msg.body])
+        self.gateway_socket.send_multipart([
+            msg.topic.encode('utf-8'),
+            msg.body.encode('utf-8'),
+        ])


### PR DESCRIPTION
The latest python3 moksha/fedmsg stuff makes it such that things are more
explicitly bytes/unicode on the frontiers/core of fedmsg.  Here, we have to
adopt that same order in the gateway too (which is kind of an edge service
anyways).
