### PR TITLE
fedmsg/meta: make sure an empty subtopic returns an empty string

### DIFF
--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -73,10 +73,12 @@ class BaseProcessor(object):
     def handle_msg(self, msg, **config):
         """
         If we can handle the given message, return the remainder of the topic.
+
+        Returns None if we can't handle the message.
         """
         match = self.__prefix__.match(msg['topic'])
         if match:
-            return match.groups()[-1]
+            return match.groups()[-1] or ""
 
     def title(self, msg, **config):
         return '.'.join(msg['topic'].split('.')[3:])

--- a/fedmsg/tests/test_meta.py
+++ b/fedmsg/tests/test_meta.py
@@ -122,7 +122,7 @@ class TestProcessorRegex(unittest.TestCase):
             'topic': 'org.fedoraproject.dev.git.push',
         }
         result = self.proc.handle_msg(fake_message, **self.config)
-        assert result, "Proc didn't say it could handle the message."
+        assert result is not None, "Proc didn't say it could handle the message."
 
     def test_processor_handle_miss(self):
         """ Test that a proc says it won't handle what it shouldn't. """
@@ -130,8 +130,15 @@ class TestProcessorRegex(unittest.TestCase):
             'topic': 'org.fedoraproject.dev.github.push',
         }
         result = self.proc.handle_msg(fake_message, **self.config)
-        assert not result, "Proc falsely claimed it could handle the msg."
+        assert result is None, "Proc falsely claimed it could handle the msg."
 
+    def test_processor_handle_empty_subtopic(self):
+        """Test that a processor will handle a message with an empty subtopic"""
+        fake_message = {
+            'topic': 'org.fedoraproject.dev.git',
+        }
+        result = self.proc.handle_msg(fake_message, **self.config)
+        assert result is "", "Proc said it couldn't handle the msg."
 
 class Base(unittest.TestCase):
     msg = None


### PR DESCRIPTION
33fcd3aa7e38f0fbea36159df2fc42380bb41930 broke fedmsg_meta_debian. Here's the fix :)
