### PR TITLE
Require psutil in the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ install_requires = [
     'pygments',
     'six',
     #'daemon',
-    #'psutil',
+    'psutil',
 
     # These are "optional" for now to make installation from pypi easier.
     #'M2Crypto',


### PR DESCRIPTION
With the recent message backlog changes from b04dd8d3fac9b7aae0f15b6307aaa3e0f964a04a, there is now a top-level import of psutil, which means we need an egg dependency on it to make things functional when pip installing.
