### PR TITLE
Handle the situation where in old message the 'username' key does not exists

### DIFF
--- a/fedmsg/meta/announce.py
+++ b/fedmsg/meta/announce.py
@@ -34,4 +34,7 @@ class AnnounceProcessor(BaseProcessor):
         return msg['msg']['link']
 
     def usernames(self, msg, **config):
-        return set([msg['username']])
+        users = set()
+        if 'username' in msg:
+            users.update(set([msg['username']]))
+        return users


### PR DESCRIPTION
With this commit processing an old message with fedmsg_meta will not break
if that old message does not have the 'username' key.
