### PR TITLE
Remove comments primarily for development.

### DIFF
--- a/fedmsg.d/endpoints.py
+++ b/fedmsg.d/endpoints.py
@@ -28,5 +28,8 @@ config = dict(
             "tcp://hub.fedoraproject.org:9940",
             #"tcp://stg.fedoraproject.org:9940",
         ],
+        #"debian-infrastructure": [
+        #    "tcp://fedmsg.olasd.eu:9940",
+        #],
     },
 )


### PR DESCRIPTION
When these get distributed to end users, they can be confusing.
