### PR TITLE
Restart services on failure (systemd).

### DIFF
--- a/initsys/systemd/fedmsg-gateway.service
+++ b/initsys/systemd/fedmsg-gateway.service
@@ -8,6 +8,7 @@ ExecStart=/usr/bin/fedmsg-gateway
 Type=simple
 User=fedmsg
 Group=fedmsg
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/initsys/systemd/fedmsg-hub.service
+++ b/initsys/systemd/fedmsg-hub.service
@@ -8,6 +8,7 @@ ExecStart=/usr/bin/fedmsg-hub
 Type=simple
 User=fedmsg
 Group=fedmsg
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/initsys/systemd/fedmsg-irc.service
+++ b/initsys/systemd/fedmsg-irc.service
@@ -8,6 +8,7 @@ ExecStart=/usr/bin/fedmsg-irc
 Type=simple
 User=fedmsg
 Group=fedmsg
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/initsys/systemd/fedmsg-relay.service
+++ b/initsys/systemd/fedmsg-relay.service
@@ -8,6 +8,7 @@ ExecStart=/usr/bin/fedmsg-relay
 Type=simple
 User=fedmsg
 Group=fedmsg
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This way, when the badges backend crashes for whatever reason, it will
automatically start itself back up.
