### PR TITLE
Docs - rename SERVICE to CATEGORY.

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -233,12 +233,13 @@ The scheme
 
 Event topics will follow the rule::
 
- org.fedoraproject.ENV.SERVICE.OBJECT[.SUBOBJECT].EVENT
+ org.fedoraproject.ENV.CATEGORY.OBJECT[.SUBOBJECT].EVENT
 
 Where:
 
  - ``ENV`` is one of `dev`, `stg`, or `production`.
- - ``SERVICE`` is something like `koji`, `bodhi`, or `fedoratagger`
+ - ``CATEGORY`` is the name of the service emitting the message -- something
+   like `koji`, `bodhi`, or `fedoratagger`
  - ``OBJECT`` is something like `package`, `user`, or `tag`
  - ``SUBOBJECT`` is something like `owner` or `build` (in the case where
    ``OBJECT`` is `package`, for instance)

--- a/doc/proposal.rst
+++ b/doc/proposal.rst
@@ -357,12 +357,13 @@ The scheme
 
 Event topics will follow the rule::
 
- org.fedoraproject.ENV.SERVICE.OBJECT[.SUBOBJECT].EVENT
+ org.fedoraproject.ENV.CATEGORY.OBJECT[.SUBOBJECT].EVENT
 
 Where:
 
  - ``ENV`` is one of `dev`, `stg`, or `production`.
- - ``SERVICE`` is something like `koji`, `bodhi`, or `fedoratagger`
+ - ``CATEGORY`` is the name of the service emitting the message -- something
+   like `koji`, `bodhi`, or `fedoratagger`
  - ``OBJECT`` is something like `package`, `user`, or `tag`
  - ``SUBOBJECT`` is something like `owner` or `build` (in the case where
    ``OBJECT`` is `package`, for instance)


### PR DESCRIPTION
Since we use the name 'category' for this bit in datagrepper -- the
thing that everyone is using to call up messages -- we should be
consistent in the docs and use the same language.
