### PR TITLE
Fix ValueError when using gpg and gpg_home is not set

### DIFF
--- a/fedmsg/crypto/__init__.py
+++ b/fedmsg/crypto/__init__.py
@@ -216,7 +216,7 @@ def validate(message, **config):
 
     cfg = copy.deepcopy(config)
     if 'gpg_home' not in cfg:
-        cfg['gpg_honme'] = os.path.expanduser('~/.gnupg/')
+        cfg['gpg_home'] = os.path.expanduser('~/.gnupg/')
 
     if 'ssldir' not in cfg:
         cfg['ssldir'] = '/etc/pki/fedmsg'


### PR DESCRIPTION
There is a simple type-o in the config key that prevents this from working.