### PR TITLE
Surface CRL errors.

### DIFF
--- a/fedmsg/crypto/x509.py
+++ b/fedmsg/crypto/x509.py
@@ -246,7 +246,8 @@ def _load_remote_cert(location, cache, cache_expiry, **config):
             with open(cache, 'w') as f:
                 f.write(response.content)
         except requests.exceptions.ConnectionError:
-            log.warn("Could not access %r" % location)
+            log.error("Could not access %r" % location)
+            raise
         except IOError as e:
             # If we couldn't write to the specified cache location, try a
             # similar place but inside our home directory instead.


### PR DESCRIPTION
This should fix the bug reported here:
https://bugzilla.redhat.com/show_bug.cgi?id=1189082

If there's a network error and the CRL is not reachable, currently
fedmsg just quietly returns the local path where the CRL should be, even
though it hasn't been downloaded.  This should surface that exception to
the user of the library.