### PR TITLE
Handle multiple topics.

### DIFF
--- a/fedmsg/consumers/__init__.py
+++ b/fedmsg/consumers/__init__.py
@@ -187,14 +187,20 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
         data = _make_query()
 
         # Grab and smash subsequent pages if there are any
+        interesting_topics = self.topic
+        if not isinstance(interesting_topics, list):
+            interesting_topics = [interesting_topics]
+
         for page in range(1, data['pages'] + 1):
             self.log.info("Retrieving datagrepper page %i of %i" % (
                 page, data['pages']))
             data = _make_query(page=page)
 
             for message in data['raw_messages']:
-                if message['topic'].startswith(self.topic[:-1]):
-                    yield message
+                for topic in interesting_topics:
+                    if message['topic'].startswith(topic[:-1]):
+                        yield message
+                        break
 
     def validate(self, message):
         """ This needs to raise an exception, caught by moksha. """

--- a/fedmsg/consumers/__init__.py
+++ b/fedmsg/consumers/__init__.py
@@ -185,7 +185,6 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
 
         # Grab the first page of results
         data = _make_query()
-        messages = data['raw_messages']
 
         # Grab and smash subsequent pages if there are any
         for page in range(1, data['pages'] + 1):


### PR DESCRIPTION
Whoops!  Consumers can possibly declare their ``self.topic`` to be a list.
Here we get pages of results from datagrepper and only yield the messages
if the topic matches *any one* of the topics that we're interested in.