### PR TITLE
Scrub args from keywords before initializing.

### DIFF
--- a/fedmsg/__init__.py
+++ b/fedmsg/__init__.py
@@ -19,6 +19,7 @@
 #
 """ Fedora Messaging Client API """
 
+import inspect
 import threading
 
 import fedmsg.core
@@ -62,9 +63,16 @@ def init(**kw):
 
 def API_function(doc=None):
     def api_function(func):
+        scrub = inspect.getargspec(func).args
 
         def _wrapper(*args, **kw):
             if not hasattr(__local, '__context'):
+                kw = kw.copy()
+
+                for arg in scrub:
+                    if arg in kw:
+                        del kw[arg]
+
                 init(**kw)
                 assert(__local.__context)
 


### PR DESCRIPTION
This is wild.

The symptom you'd get is this:  The *first* time
``fedmsg.publish(topic=topic, msg=dict(...))`` is ever called, fedmsg
isn't initialized yet.  Those topic and msg arguments are passed through
to ``init(**kw)`` as extra keyword arguments and so "topic" and "msg"
appear in the global config dict (internally).

This never mattered in practice.  They were there, and noone cared.

I'm hitting it now because in fmn, we try to call
``fedmsg.meta.msg2link(msg=msg, **config)`` but there is a ``msg`` key
in config from the first time ``publish`` was called and so it fails
with "cannot have two keyword arguments named 'msg'".