### PR TITLE
Attempt to avoid infinite recursion when finding the list of new revs.

### DIFF
--- a/extras/git-hooks/post-receive
+++ b/extras/git-hooks/post-receive
@@ -88,6 +88,11 @@ for line in lines:
     def _build_commit(rev):
         commit = repo.revparse_single(rev)
 
+        # Tags are a little funny, and vary between versions of pygit2, so we'll
+        # just ignore them as far as fedmsg is concerned.
+        if isinstance(commit, pygit2.Tag):
+            return None
+
         files, total = build_stats(commit)
 
         return dict(

--- a/extras/git-hooks/post-receive
+++ b/extras/git-hooks/post-receive
@@ -26,18 +26,29 @@ config['active'] = True
 config['endpoints']['relay_inbound'] = config['relay_inbound']
 fedmsg.init(name='relay_inbound', cert_prefix='scm', **config)
 
-def revs_between(head, base):
+def revs_between(head, base, seen=None):
+    """ Yield revisions between HEAD and BASE.
+
+    Detect if a revision appears multiple times and stop recursion.
+    """
+
+    seen = seen or []
+    rev = unicode(head.id)
+
     bail = False
+    if not rev in seen:
+        seen.append(rev)
+        yield rev
 
-    yield unicode(head.id)
-
-    for parent in head.parents:
-        if parent.id == base.id:
-            bail = True
+        for parent in head.parents:
+            if parent.id == base.id:
+                bail = True
+    else:
+        bail = True
 
     if not bail:
         for parent in head.parents:
-            for rev in revs_between(parent, base):
+            for rev in revs_between(parent, base, seen=seen):
                 yield rev
 
 

--- a/extras/git-hooks/post-receive
+++ b/extras/git-hooks/post-receive
@@ -131,6 +131,7 @@ for line in lines:
 
     commits = map(_build_commit, revs)
 
+    print "* Publishing information for %i commits" % len(commits)
     for commit in commits:
 
         if commit is None:

--- a/extras/git-hooks/post-receive
+++ b/extras/git-hooks/post-receive
@@ -26,30 +26,35 @@ config['active'] = True
 config['endpoints']['relay_inbound'] = config['relay_inbound']
 fedmsg.init(name='relay_inbound', cert_prefix='scm', **config)
 
-def revs_between(head, base, seen=None):
-    """ Yield revisions between HEAD and BASE.
+def revs_between(head, ancestors):
+    """ Yield revisions between HEAD and any of the ancestors. """
 
-    Detect if a revision appears multiple times and stop recursion.
-    """
+    # For each of my parents
+    for parent in head.parents:
+        # If it is not one of the known ancestors
+        if not parent.id in ancestors:
+            # Then yield all of its history, meeting the same conditions
+            for rev in revs_between(parent, ancestors):
+                yield rev
+
+    if not head.id in ancestors:
+        yield unicode(head.id)
+
+
+def gather_ancestors(commit, seen=None):
+    """ Yield all ancestors commits of a given commit. """
 
     seen = seen or []
-    rev = unicode(head.id)
+    idx = unicode(commit.id)
 
-    bail = False
-    if not rev in seen:
-        seen.append(rev)
-        yield rev
+    if not idx in seen:
+        seen.append(idx)
 
-        for parent in head.parents:
-            if parent.id == base.id:
-                bail = True
-    else:
-        bail = True
+        for parent in commit.parents:
+            for rev in gather_ancestors(parent, seen=seen):
+                yield rev.id
 
-    if not bail:
-        for parent in head.parents:
-            for rev in revs_between(parent, base, seen=seen):
-                yield rev
+        yield commit.id
 
 
 def build_stats(commit):
@@ -92,7 +97,8 @@ for line in lines:
 
     try:
         base = repo.revparse_single(base)
-        revs = revs_between(head, base)
+        ancestors = gather_ancestors(base)
+        revs = revs_between(head, ancestors)
     except KeyError:
         revs = [unicode(head.id)]
 

--- a/extras/git-hooks/post-receive
+++ b/extras/git-hooks/post-receive
@@ -38,23 +38,23 @@ def revs_between(head, ancestors):
                 yield rev
 
     if not head.id in ancestors:
-        yield unicode(head.id)
+        yield head.id
 
 
 def gather_ancestors(commit, seen=None):
     """ Yield all ancestors commits of a given commit. """
 
     seen = seen or []
-    idx = unicode(commit.id)
+    idx = commit.id
 
     if not idx in seen:
         seen.append(idx)
 
         for parent in commit.parents:
-            for rev in gather_ancestors(parent, seen=seen):
-                yield rev.id
+            for revid in gather_ancestors(parent, seen=seen):
+                yield revid
 
-        yield commit.id
+        yield idx
 
 
 def build_stats(commit):
@@ -97,13 +97,13 @@ for line in lines:
 
     try:
         base = repo.revparse_single(base)
-        ancestors = gather_ancestors(base)
+        ancestors = list(gather_ancestors(base))
         revs = revs_between(head, ancestors)
     except KeyError:
-        revs = [unicode(head.id)]
+        revs = [head.id]
 
     def _build_commit(rev):
-        commit = repo.revparse_single(rev)
+        commit = repo.revparse_single(unicode(rev))
 
         # Tags are a little funny, and vary between versions of pygit2, so we'll
         # just ignore them as far as fedmsg is concerned.
@@ -122,7 +122,7 @@ for line in lines:
                 files=files,
                 total=total,
             ),
-            rev=rev,
+            rev=unicode(rev),
             path=abspath,
             repo=repo_name,
             branch=branch,


### PR DESCRIPTION
These are changes that have already been applied to our ansible repo, but I'd appreciate review to see if they make sense/look right.

We hit a scenario today that I don't understand where a set of commits pushed by pbrobinson to the 'file' package sent the fedmsg hook into a loop that published some 30k messages before nirik was able to kill it.

There might be a better way than this to detect what commits should and shouldn't be published.  Ideas welcome.