### PR TITLE
Re-use the produce_template function for consistency.

### DIFF
--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -50,7 +50,6 @@ End users can have multiple plugin sets installed simultaneously.
 
 """
 
-import arrow
 import six
 
 # gettext is used for internationalization.  I have tested that it can produce
@@ -65,6 +64,7 @@ else:
 
 
 from fedmsg.meta.default import DefaultProcessor
+from fedmsg.meta.base import BaseConglomerator
 
 import logging
 log = logging.getLogger("fedmsg")
@@ -181,19 +181,14 @@ def conglomerate(messages, **config):
             continue
 
         # For ungrouped ones, replace them with a fake conglomerate
-        messages[i] = {
-            'subtitle': msg2subtitle(message, **config),
+        messages[i] = BaseConglomerator.produce_template([message], **config)
+        # And fill out the fields that fully-implemented conglomerators would
+        # normally fill out.
+        messages[i].update({
             'link': msg2link(message, **config),
-            'icon': msg2icon(message, **config),
+            'subtitle': msg2subtitle(message, **config),
             'secondary_icon': msg2secondary_icon(message, **config),
-            'start_time': message['timestamp'],
-            'end_time': message['timestamp'],
-            'timestamp': message['timestamp'],
-            'human_time': arrow.get(message['timestamp']).humanize(),
-            'usernames': msg2usernames(message, **config),
-            'packages': msg2packages(message, **config),
-            'msg_ids': [message['msg_id']],
-        }
+        })
 
     return messages
 

--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -252,7 +252,8 @@ class BaseConglomerator(object):
         # If we're done, we're done.
         return None, None
 
-    def produce_template(self, constituents, **config):
+    @classmethod
+    def produce_template(cls, constituents, **config):
         """ Helper function used by `merge`.
         Produces the beginnings of a merged conglomerate message that needs to
         be later filled out by a subclass.
@@ -266,17 +267,17 @@ class BaseConglomerator(object):
         timestamps = [_extract_timestamp(msg) for msg in constituents]
         average_timestamp = sum(timestamps) / N
 
+        # Avoid circular import
+        import fedmsg.meta as fm
+
         usernames = set(sum([
-            list(self.processor.usernames(msg, **config))
+            list(fm.msg2usernames(msg, **config))
             for msg in constituents], []))
         packages = set(sum([
-            list(self.processor.packages(msg, **config))
+            list(fm.msg2packages(msg, **config))
             for msg in constituents], []))
         topics = set([msg['topic'] for msg in constituents])
         categories = set([t.split('.')[3] for t in topics])
-
-        # Avoid circular import
-        import fedmsg.meta as fm
 
         # Include metadata about constituent messages in the aggregate
         # http://da.gd/12Eso
@@ -302,7 +303,7 @@ class BaseConglomerator(object):
             'packages': packages,
             'topics': topics,
             'categories': categories,
-            'icon': self.processor.__icon__,
+            'icon': fm.msg2icon(constituents[0], **config),
         }
 
     @staticmethod


### PR DESCRIPTION
As it stood before, these two kinds of things had different templates:

- Actual conglomerations of multiple messages.
- Fake conglomerations of a single message.

This re-use of code ensures that they will actually look the same.