### PR TITLE
Publish git commits in chronological order.

### DIFF
--- a/extras/git-hooks/post-receive
+++ b/extras/git-hooks/post-receive
@@ -118,7 +118,7 @@ for line in lines:
     commits = map(_build_commit, revs)
 
     print "* Publishing information for %i commits" % len(commits)
-    for commit in commits:
+    for commit in reversed(commits):
         if commit is None:
             continue
 


### PR DESCRIPTION
We currently publish them newest to oldest which can be really confusing if you
receive them over email.  @remicollet pointed this out in ``#fedora-devel``
last week.