### PR TITLE
Initial shot at Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
  - "2.6"
  - "2.7"
  - "3.3"
+ - "3.4"
 
 install:
  - python setup.py install
@@ -18,3 +19,4 @@ notifications:
 matrix:
   allow_failures:
     - python: "3.3"
+    - python: "3.4"

--- a/extras/git-hooks/post-receive
+++ b/extras/git-hooks/post-receive
@@ -8,6 +8,7 @@ import sys
 from collections import defaultdict
 
 import pygit2
+import six
 
 import fedmsg
 import fedmsg.config
@@ -21,7 +22,7 @@ username = getpass.getuser()
 
 repo = pygit2.Repository(abspath)
 
-print "Emitting a message to the fedmsg bus."
+print("Emitting a message to the fedmsg bus.")
 config = fedmsg.config.load_config([], None)
 config['active'] = True
 config['endpoints']['relay_inbound'] = config['relay_inbound']
@@ -89,7 +90,7 @@ for line in lines:
         revs = [head.id]
 
     def _build_commit(rev):
-        commit = repo.revparse_single(unicode(rev))
+        commit = repo.revparse_single(six.text_type(rev))
 
         # Tags are a little funny, and vary between versions of pygit2, so we'll
         # just ignore them as far as fedmsg is concerned.
@@ -108,7 +109,7 @@ for line in lines:
                 files=files,
                 total=total,
             ),
-            rev=unicode(rev),
+            rev=six.text_type(rev),
             path=abspath,
             repo=repo_name,
             branch=branch,
@@ -117,7 +118,7 @@ for line in lines:
 
     commits = map(_build_commit, revs)
 
-    print "* Publishing information for %i commits" % len(commits)
+    print("* Publishing information for %i commits" % len(commits))
     for commit in reversed(commits):
         if commit is None:
             continue

--- a/extras/stress/mass-sub.py
+++ b/extras/stress/mass-sub.py
@@ -42,17 +42,17 @@ for thread in threads:
     thread.start()
 
 pid = os.getpid()
-print prefix, "Checking pid", pid
+print(prefix, "Checking pid", pid)
 target = 200
 length = 0
 while length <= target:
     length = len(os.listdir("/proc/%i/fd/" % os.getpid()))
-    print prefix, length, "is less than", target
+    print(prefix, length, "is less than", target)
     time.sleep(1)
 
-print prefix, "ready to receive..."
+print(prefix, "ready to receive...")
 
 for thread in threads:
     thread.join()
 
-print prefix, "Done."
+print(prefix, "Done.")

--- a/fedmsg/commands/__init__.py
+++ b/fedmsg/commands/__init__.py
@@ -103,4 +103,4 @@ class BaseCommand(object):
             try:
                 return self.run()
             except KeyboardInterrupt:
-                print
+                print()

--- a/fedmsg/commands/collectd.py
+++ b/fedmsg/commands/collectd.py
@@ -54,7 +54,7 @@ class CollectdConsumer(FedmsgConsumer):
         # Print out the collectd feedback.
         # This is sent to stdout while other log messages are sent to stderr.
         for k, v in sorted(self._dict.items()):
-            print self.formatter(k, v)
+            print(self.formatter(k, v))
 
         # Reset each entry to zero
         for k, v in sorted(self._dict.items()):

--- a/fedmsg/commands/tail.py
+++ b/fedmsg/commands/tail.py
@@ -25,6 +25,7 @@ import sys
 import pygments
 import pygments.lexers
 import pygments.formatters
+import six
 
 import fedmsg
 import fedmsg.encoding
@@ -139,7 +140,7 @@ class TailCommand(BaseCommand):
         if self.config['query']:
             def formatter(d):
                 result = fedmsg.utils.dict_query(d, self.config['query'])
-                return ", ".join([unicode(value) for value in result.values()])
+                return ", ".join([six.text_type(value) for value in result.values()])
 
         if self.config['terse']:
             formatter = lambda d: "\n" + fedmsg.meta.msg2repr(d, **self.config)

--- a/fedmsg/commands/trigger.py
+++ b/fedmsg/commands/trigger.py
@@ -21,7 +21,7 @@ import re
 import subprocess
 import sys
 import threading
-import Queue
+from six.moves import queue
 
 import fedmsg
 import fedmsg.encoding
@@ -110,11 +110,11 @@ class TriggerCommand(BaseCommand):
         max_queue_size = int(self.config['max_queue_size'])
 
         timer = None
-        queue = Queue.Queue()
+        que = queue.Queue()
 
         def execute_queue():
-            while not queue.empty():
-                message = queue.get()
+            while not que.empty():
+                message = que.get()
 
                 result = self.run_command(self.config['command'], message)
 
@@ -129,7 +129,7 @@ class TriggerCommand(BaseCommand):
                 if not inclusive_regexp.search(topic):
                     continue
 
-                queue.put(message)
+                que.put(message)
 
                 if timer is not None:
                     # Try to cancel it
@@ -138,8 +138,8 @@ class TriggerCommand(BaseCommand):
                     # Either there was no timer yet, or it was still waiting
                     # -> Let's start a new one
                     if (max_queue_size > 0 and
-                            queue.qsize() > max_queue_size):
-                        # If the queue is too big, let's just run it NOW
+                            que.qsize() > max_queue_size):
+                        # If the que is too big, let's just run it NOW
                         timer = threading.Timer(0, execute_queue)
                     else:
                         timer = threading.Timer(wait_for,

--- a/fedmsg/core.py
+++ b/fedmsg/core.py
@@ -316,7 +316,7 @@ class FedMsgContext(object):
         failed_hostnames = []
         subs = {}
         watched_names = {}
-        for _name, endpoint_list in self.c['endpoints'].iteritems():
+        for _name, endpoint_list in six.iteritems(self.c['endpoints']):
 
             # You never want to actually subscribe to this thing, but sometimes
             # it appears in the endpoints list due to a hack where it gets

--- a/fedmsg/crypto/x509.py
+++ b/fedmsg/crypto/x509.py
@@ -41,6 +41,11 @@ except ImportError as e:
     log.warn("Crypto disabled %r" % e)
     disabled = True
 
+import six
+
+if six.PY3:
+    long = int
+
 
 def sign(message, ssldir=None, certname=None, **config):
     """ Insert two new fields into the message dict and return it.

--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -23,6 +23,7 @@ import re
 import time
 
 import arrow
+import six
 
 
 class BaseProcessor(object):
@@ -187,6 +188,7 @@ class BaseProcessor(object):
         return dict()
 
 
+@six.add_metaclass(abc.ABCMeta)
 class BaseConglomerator(object):
     """ Base Conglomerator.  This abstract base class must be extended.
 
@@ -202,8 +204,6 @@ class BaseConglomerator(object):
     This BaseConglomerator is meant to be extended many times over to provide
     plugins that know how to conglomerate different combinations of messages.
     """
-    __metaclass__ = abc.ABCMeta
-
     def __init__(self, processor, internationalization_callable, **conf):
         self.processor = processor
         self._ = internationalization_callable
@@ -320,7 +320,12 @@ class BaseConglomerator(object):
         if not items:
             return "(nothing)"
 
-        items = list(set(items))
+        # uniqify items while preserving the order
+        olditems = items
+        items = []
+        for i in olditems:
+            if i not in items:
+                items.append(i)
 
         if len(items) == 1:
             return items[0]

--- a/fedmsg/tests/test_commands.py
+++ b/fedmsg/tests/test_commands.py
@@ -1,6 +1,4 @@
 import unittest
-from mock import Mock
-from mock import patch
 from datetime import datetime
 import time
 import json
@@ -16,6 +14,7 @@ from fedmsg.commands.tail import TailCommand
 from fedmsg.commands.relay import RelayCommand
 from fedmsg.commands.config import config as config_command
 import fedmsg.consumers.relay
+from fedmsg.tests.test_utils import mock
 
 from nose.tools import eq_
 
@@ -38,8 +37,8 @@ class TestCommands(unittest.TestCase):
         del self.local
         self.local = None
 
-    @patch("sys.argv", new_callable=lambda: ["fedmsg-logger"])
-    @patch("sys.stdout", new_callable=six.StringIO)
+    @mock.patch("sys.argv", new_callable=lambda: ["fedmsg-logger"])
+    @mock.patch("sys.stdout", new_callable=six.StringIO)
     def test_logger_basic(self, stdout, argv):
 
         test_input = "a message for you"
@@ -55,17 +54,17 @@ class TestCommands(unittest.TestCase):
             msgs.append(msg)
 
         config = {}
-        with patch("fedmsg.__local", self.local):
-            with patch("fedmsg.config.__cache", config):
-                with patch("fedmsg.core.FedMsgContext.publish", mock_publish):
-                    with patch("sys.stdin", new_callable=stdin):
+        with mock.patch("fedmsg.__local", self.local):
+            with mock.patch("fedmsg.config.__cache", config):
+                with mock.patch("fedmsg.core.FedMsgContext.publish", mock_publish):
+                    with mock.patch("sys.stdin", new_callable=stdin):
                         command = LoggerCommand()
                         command.execute()
 
         eq_(msgs, [{'log': test_input}])
 
-    @patch("sys.argv", new_callable=lambda: ["fedmsg-logger", "--json-input"])
-    @patch("sys.stdout", new_callable=six.StringIO)
+    @mock.patch("sys.argv", new_callable=lambda: ["fedmsg-logger", "--json-input"])
+    @mock.patch("sys.stdout", new_callable=six.StringIO)
     def test_logger_json(self, stdout, argv):
 
         test_input_dict = {"hello": "world"}
@@ -82,25 +81,25 @@ class TestCommands(unittest.TestCase):
             msgs.append(msg)
 
         config = {}
-        with patch("fedmsg.__local", self.local):
-            with patch("fedmsg.config.__cache", config):
-                with patch("fedmsg.core.FedMsgContext.publish", mock_publish):
-                    with patch("sys.stdin", new_callable=stdin):
+        with mock.patch("fedmsg.__local", self.local):
+            with mock.patch("fedmsg.config.__cache", config):
+                with mock.patch("fedmsg.core.FedMsgContext.publish", mock_publish):
+                    with mock.patch("sys.stdin", new_callable=stdin):
                         command = LoggerCommand()
                         command.execute()
 
         eq_(msgs, [test_input_dict])
 
-    @patch("sys.argv", new_callable=lambda: ["fedmsg-tail"])
-    @patch("sys.stdout", new_callable=six.StringIO)
+    @mock.patch("sys.argv", new_callable=lambda: ["fedmsg-tail"])
+    @mock.patch("sys.stdout", new_callable=six.StringIO)
     def test_tail_basic(self, stdout, argv):
         def mock_tail(self, topic="", passive=False, **kw):
             yield ("name", "endpoint", "topic", dict(topic="topic"))
 
         config = {}
-        with patch("fedmsg.__local", self.local):
-            with patch("fedmsg.config.__cache", config):
-                with patch("fedmsg.core.FedMsgContext.tail_messages",
+        with mock.patch("fedmsg.__local", self.local):
+            with mock.patch("fedmsg.config.__cache", config):
+                with mock.patch("fedmsg.core.FedMsgContext.tail_messages",
                            mock_tail):
                     command = fedmsg.commands.tail.TailCommand()
                     command.execute()
@@ -109,8 +108,8 @@ class TestCommands(unittest.TestCase):
         expected = "{'topic': 'topic'}\n"
         assert(output.endswith(expected))
 
-    @patch("sys.argv", new_callable=lambda: ["fedmsg-tail", "--pretty"])
-    @patch("sys.stdout", new_callable=six.StringIO)
+    @mock.patch("sys.argv", new_callable=lambda: ["fedmsg-tail", "--pretty"])
+    @mock.patch("sys.stdout", new_callable=six.StringIO)
     def test_tail_pretty(self, stdout, argv):
         msgs = []
 
@@ -125,9 +124,9 @@ class TestCommands(unittest.TestCase):
             yield ("name", "endpoint", "topic", msg)
 
         config = {}
-        with patch("fedmsg.__local", self.local):
-            with patch("fedmsg.config.__cache", config):
-                with patch("fedmsg.core.FedMsgContext.tail_messages",
+        with mock.patch("fedmsg.__local", self.local):
+            with mock.patch("fedmsg.config.__cache", config):
+                with mock.patch("fedmsg.core.FedMsgContext.tail_messages",
                            mock_tail):
                     command = fedmsg.commands.tail.TailCommand()
                     command.execute()
@@ -136,8 +135,8 @@ class TestCommands(unittest.TestCase):
         expected = "{'msg': {'hello': 'world'},"
         assert(expected in output)
 
-    @patch("sys.argv", new_callable=lambda: ["fedmsg-tail", "--really-pretty"])
-    @patch("sys.stdout", new_callable=six.StringIO)
+    @mock.patch("sys.argv", new_callable=lambda: ["fedmsg-tail", "--really-pretty"])
+    @mock.patch("sys.stdout", new_callable=six.StringIO)
     def test_tail_really_pretty(self, stdout, argv):
         msgs = []
 
@@ -152,9 +151,9 @@ class TestCommands(unittest.TestCase):
             yield ("name", "endpoint", "topic", msg)
 
         config = {}
-        with patch("fedmsg.__local", self.local):
-            with patch("fedmsg.config.__cache", config):
-                with patch("fedmsg.core.FedMsgContext.tail_messages",
+        with mock.patch("fedmsg.__local", self.local):
+            with mock.patch("fedmsg.config.__cache", config):
+                with mock.patch("fedmsg.core.FedMsgContext.tail_messages",
                            mock_tail):
                     command = fedmsg.commands.tail.TailCommand()
                     command.execute()
@@ -166,7 +165,7 @@ class TestCommands(unittest.TestCase):
 
         assert(expected in output)
 
-    @patch("sys.argv", new_callable=lambda: ["fedmsg-relay"])
+    @mock.patch("sys.argv", new_callable=lambda: ["fedmsg-relay"])
     def test_relay(self, argv):
         actual_options = []
 
@@ -174,9 +173,9 @@ class TestCommands(unittest.TestCase):
             actual_options.append(options)
 
         config = {}
-        with patch("fedmsg.__local", self.local):
-            with patch("fedmsg.config.__cache", config):
-                with patch("moksha.hub.main", mock_main):
+        with mock.patch("fedmsg.__local", self.local):
+            with mock.patch("fedmsg.config.__cache", config):
+                with mock.patch("moksha.hub.main", mock_main):
                     command = fedmsg.commands.relay.RelayCommand()
                     command.execute()
 
@@ -188,44 +187,44 @@ class TestCommands(unittest.TestCase):
             actual_options[fedmsg.consumers.relay.RelayConsumer.config_key]
         )
 
-    @patch("sys.argv", new_callable=lambda: ["fedmsg-config"])
-    @patch("sys.stdout", new_callable=six.StringIO)
+    @mock.patch("sys.argv", new_callable=lambda: ["fedmsg-config"])
+    @mock.patch("sys.stdout", new_callable=six.StringIO)
     def test_config_basic(self, stdout, argv):
-        with patch('fedmsg.config.__cache', {}):
+        with mock.patch('fedmsg.config.__cache', {}):
             config_command()
 
         output = stdout.getvalue()
         output_conf = json.loads(output)
 
-        with patch('fedmsg.config.__cache', {}):
+        with mock.patch('fedmsg.config.__cache', {}):
             fedmsg_conf = fedmsg.config.load_config()
 
         eq_(output_conf, fedmsg_conf)
 
-    @patch("sys.argv", new_callable=lambda: [
+    @mock.patch("sys.argv", new_callable=lambda: [
         "fedmsg-config", "--query", "endpoints",
     ])
-    @patch("sys.stdout", new_callable=six.StringIO)
+    @mock.patch("sys.stdout", new_callable=six.StringIO)
     def test_config_query(self, stdout, argv):
-        with patch('fedmsg.config.__cache', {}):
+        with mock.patch('fedmsg.config.__cache', {}):
             config_command()
 
         output = stdout.getvalue()
         output_conf = json.loads(output)
 
-        with patch('fedmsg.config.__cache', {}):
+        with mock.patch('fedmsg.config.__cache', {}):
             fedmsg_conf = fedmsg.config.load_config()
 
         eq_(output_conf, fedmsg_conf["endpoints"])
 
-    @patch("sys.argv", new_callable=lambda: [
+    @mock.patch("sys.argv", new_callable=lambda: [
         "fedmsg-config", "--query", "endpoints.broken",
     ])
-    @patch("sys.stdout", new_callable=six.StringIO)
-    @patch("sys.stderr", new_callable=six.StringIO)
+    @mock.patch("sys.stdout", new_callable=six.StringIO)
+    @mock.patch("sys.stderr", new_callable=six.StringIO)
     def test_config_query_broken(self, stderr, stdout, argv):
         try:
-            with patch('fedmsg.config.__cache', {}):
+            with mock.patch('fedmsg.config.__cache', {}):
                 config_command()
         except SystemExit as exc:
             eq_(exc.code, 1)
@@ -240,18 +239,18 @@ class TestCommands(unittest.TestCase):
         eq_(output.strip(), "")
         eq_(error.strip(), "Key `endpoints.broken` does not exist in config")
 
-    @patch("sys.argv", new_callable=lambda: [
+    @mock.patch("sys.argv", new_callable=lambda: [
         "fedmsg-config", "--disable-defaults", "--config-filename", CONF_FILE,
     ])
-    @patch("sys.stdout", new_callable=six.StringIO)
+    @mock.patch("sys.stdout", new_callable=six.StringIO)
     def test_config_single_file(self, stdout, argv):
-        with patch('fedmsg.config.__cache', {}):
+        with mock.patch('fedmsg.config.__cache', {}):
             config_command()
 
         output = stdout.getvalue()
         output_conf = json.loads(output)
 
-        with patch('fedmsg.config.__cache', {}):
+        with mock.patch('fedmsg.config.__cache', {}):
             fedmsg_conf = fedmsg.config.load_config(
                 filenames=[CONF_FILE],
                 disable_defaults=True,

--- a/fedmsg/tests/test_core.py
+++ b/fedmsg/tests/test_core.py
@@ -1,9 +1,9 @@
 import unittest
 
-import mock
 import warnings
 from fedmsg.core import FedMsgContext
 from fedmsg.tests.common import load_config
+from fedmsg.tests.test_utils import mock
 
 
 class TestCore(unittest.TestCase):

--- a/fedmsg/tests/test_meta.py
+++ b/fedmsg/tests/test_meta.py
@@ -178,9 +178,9 @@ class Base(unittest.TestCase):
             else:
                 self.assertEquals(actual, expected)
         except:
-            print "Failed at:"
-            print " ", self
-            print " ", os.path.relpath(inspect.getfile(type(self))[:-1])
+            print("Failed at:")
+            print(" ", self)
+            print(" ", os.path.relpath(inspect.getfile(type(self))[:-1]))
             raise
 
     @skip_on(['msg', 'expected_title'])
@@ -361,9 +361,9 @@ class ConglomerateBase(unittest.TestCase):
         try:
             self.assertEquals(actual, self.expected)
         except:
-            print "Failed at:"
-            print " ", self
-            print " ", os.path.relpath(inspect.getfile(type(self))[:-1])
+            print("Failed at:")
+            print(" ", self)
+            print(" ", os.path.relpath(inspect.getfile(type(self))[:-1]))
             raise
 
 
@@ -380,7 +380,7 @@ class TestConglomeratorExtras(unittest.TestCase):
         self.conglomerator = fedmsg.meta.base.BaseConglomerator
 
     def test_list_to_series_simple(self):
-        original, expected = ['a', 'b', 'c'], "a, c, and b"
+        original, expected = ['a', 'b', 'c'], "a, b, and c"
         result = self.conglomerator.list_to_series(original)
         eq_(result, expected)
 

--- a/fedmsg/tests/test_utils.py
+++ b/fedmsg/tests/test_utils.py
@@ -1,6 +1,11 @@
 from nose.tools import raises, eq_
 from fedmsg.utils import load_class, dict_query
 
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
 
 def test_load_class_succeed():
     cls = load_class("shelve:Shelf")

--- a/scripts/fedmsg-map.py
+++ b/scripts/fedmsg-map.py
@@ -120,6 +120,6 @@ else:
             interval=interval,
             timestamp=int(timestamp),
             value=int(value))
-        print output
+        print(output)
         if interval - delta > 0:
             time.sleep(interval - delta)

--- a/setup.py
+++ b/setup.py
@@ -81,19 +81,20 @@ install_requires = [
 ]
 tests_require = [
     'nose',
-    'mock',
     'sqlalchemy',  # For the persistent-store test(s).
 ]
 
-if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
-    install_requires.extend([
-        'argparse',
-        'ordereddict',
-        'logutils',
-    ])
-    tests_require.extend([
-        'unittest2',
-    ])
+if sys.version_info[0] == 2:
+    tests_require.append('mock')
+    if sys.version_info[1] <= 6:
+        install_requires.extend([
+            'argparse',
+            'ordereddict',
+            'logutils',
+        ])
+        tests_require.extend([
+            'unittest2',
+        ])
 
 setup(
     name='fedmsg',


### PR DESCRIPTION
This PR contains initial changes to make fedmsg support Python 3. Some notes:
- All tests are green, but I think that doesn't really mean anything :)
- There are still some `isinstance(..., basestring)` calls and since I don't have enough knowledge about fedmsg, I'm not sure what to do with these. They seem to be used as input for `json.loads`, which only takes PY3's `str` type.
- The real problem, I think, will be M2crypto, since that doesn't support Python 3 at all for now. Maybe it would make sense to move to cryptography [1] in long term, since that seems to be *the* Python crypto library for following years.

[1] https://pypi.python.org/pypi/cryptography/