### PR TITLE
Make list_to_series return uniqified items in predictable order.

### DIFF
--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -320,12 +320,8 @@ class BaseConglomerator(object):
         if not items:
             return "(nothing)"
 
-        # uniqify items while preserving the order
-        olditems = items
-        items = []
-        for i in olditems:
-            if i not in items:
-                items.append(i)
+        # uniqify items + sort them to have predictable (==testable) ordering
+        items = list(sorted(set(items)))
 
         if len(items) == 1:
             return items[0]


### PR DESCRIPTION
This helps with testing dependent packages (e.g. fedmsg-meta-fedora-infrastructure) on Python 3, which has randomization of sets and maps turned on.