### PR TITLE
Take care with python-six

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ htmldocs
 fedmsg/tests/test_certs/gpg/random_seed
 html-docs
 status
+.tox

--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -26,6 +26,15 @@ import arrow
 import six
 
 
+def add_metaclass(metaclass):
+    """ Compat shim for el7. """
+    if hasattr(six, 'add_metaclass'):
+        return six.add_metaclass(metaclass)
+    else:
+        # Do nothing.  It's not worth it.
+        return lambda klass: klass
+
+
 class BaseProcessor(object):
     """ Base Processor.  Without being extended, this doesn't actually handle
     any messages.
@@ -188,7 +197,7 @@ class BaseProcessor(object):
         return dict()
 
 
-@six.add_metaclass(abc.ABCMeta)
+@add_metaclass(abc.ABCMeta)
 class BaseConglomerator(object):
     """ Base Conglomerator.  This abstract base class must be extended.
 

--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -22,7 +22,6 @@ import abc
 import re
 import time
 
-import arrow
 import six
 
 
@@ -278,6 +277,8 @@ class BaseConglomerator(object):
 
         # Avoid circular import
         import fedmsg.meta as fm
+        # Optional, so, avoid importing it at the topmost level
+        import arrow
 
         usernames = set(sum([
             list(fm.msg2usernames(msg, **config))

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ install_requires = [
     'six',
     #'daemon',
     'psutil',
-    'arrow',
+    #'arrow',  # This is actually optional.
 
     # These are "optional" for now to make installation from pypi easier.
     #'M2Crypto',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist = py{27}-six{13,17,19}
+downloadcache = {toxworkdir}/_download/
+
+[testenv]
+basepython =
+    py26: python2.6
+    py27: python2.7
+    py34: python3.4
+deps =
+    six13: six==1.3.0
+    six17: six==1.7.3
+    six19: six>=1.9.0
+    nose
+    mock
+    sqlalchemy
+sitepackages = False
+commands =
+    nosetests {posargs}


### PR DESCRIPTION
I ran into problems when deploying the latest release to our rhel7 nodes.  We have python-six-1.3.0 in rhel7, 1.7.3 in EPEL6, and 1.9.0 in fedora/upstream.  These changes get our tests passing on all three scenarios.