### PR TITLE
Make order of configuration files predictable

### DIFF
--- a/fedmsg/config.py
+++ b/fedmsg/config.py
@@ -298,11 +298,11 @@ def _process_arguments(declared_args, doc, config):
 def _gather_configs_in(directory):
     """ Return list of fully qualified python filenames in the given dir """
     try:
-        return [
+        return sorted([
             os.path.join(directory, fname)
             for fname in os.listdir(directory)
             if fname.endswith('.py')
-        ]
+        ])
     except OSError:
         return []
 


### PR DESCRIPTION
The order in which configuration files are loaded matters, but fedmsg.config
uses listdir, which returns files in order depending on the filesystem. Sorting
them by name should make things more predictable.