### PR TITLE
No need to rebuild fedmsg.meta processors

### DIFF
--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -75,6 +75,10 @@ class ProcessorsNotInitialized(Exception):
         raise self
     __len__ = __iter__
 
+    def __nonzero__(self):
+        return False
+    __bool__ = __nonzero__
+
 processors = ProcessorsNotInitialized("You must first call "
                                       "fedmsg.meta.make_processors(**config)")
 
@@ -92,6 +96,11 @@ def make_processors(**config):
         >>> text = fedmsg.meta.msg2repr(some_message_dict, **config)
 
     """
+
+    # If they're already initialized, then fine.
+    if processors:
+        return
+
     import pkg_resources
     global processors
     processors = []

--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -96,13 +96,13 @@ def make_processors(**config):
         >>> text = fedmsg.meta.msg2repr(some_message_dict, **config)
 
     """
+    global processors
 
     # If they're already initialized, then fine.
     if processors:
         return
 
     import pkg_resources
-    global processors
     processors = []
     for processor in pkg_resources.iter_entry_points('fedmsg.meta'):
         try:

--- a/fedmsg/tests/test_meta.py
+++ b/fedmsg/tests/test_meta.py
@@ -91,6 +91,7 @@ class TestForWarning(unittest.TestCase):
         original = fedmsg.meta.log.warn
         try:
             fedmsg.meta.log.warn = mocked_warning
+            fedmsg.meta.processors = []
             fedmsg.meta.make_processors(**self.config)
             eq_(messages, [expected])
         finally:
@@ -164,6 +165,7 @@ class Base(unittest.TestCase):
         )
         self.config['topic_prefix'] = 'org.fedoraproject'
         self.config['topic_prefix_re'] = '^org\.fedoraproject\.(dev|stg|prod)'
+        fedmsg.meta.processors = []
         fedmsg.meta.make_processors(**self.config)
 
         self.maxDiff = None
@@ -337,6 +339,7 @@ class ConglomerateBase(unittest.TestCase):
         )
         self.config['topic_prefix'] = 'org.fedoraproject'
         self.config['topic_prefix_re'] = '^org\.fedoraproject\.(dev|stg|prod)'
+        fedmsg.meta.processors = []
         fedmsg.meta.make_processors(**self.config)
 
         # Delete the msg_ids field because it is bulky and I don't want to


### PR DESCRIPTION
...if they have already been built.

This gets the fedmsg_meta test suite running 31x faster.  Compare before::

    (fedmsg_meta)❯ time $(which nosetests) -x                                                                      fedmsg_meta_fedora_infrastructure/git/develop
    Ran 3822 tests in 270.822s

    OK (SKIP=1638)
    ----------------------------------------------------------------------
    Success!
    $(which nosetests) -x  267.30s user 1.32s system 98% cpu 4:33.53 total

And after::

    (fedmsg_meta)❯ time $(which nosetests) -x                                                                      fedmsg_meta_fedora_infrastructure/git/develop
    Ran 3822 tests in 5.982s

    OK (SKIP=1638)
    ----------------------------------------------------------------------
    Success!
    $(which nosetests) -x  3.87s user 0.71s system 52% cpu 8.700 total