### PR TITLE
Add a new "subjective" api.

### DIFF
--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -298,3 +298,19 @@ def msg2emails(msg, processor, **config):
 def msg2avatars(msg, processor, **config):
     """ Return a dict mapping of usernames to avatar URLs. """
     return processor.avatars(msg, **config)
+
+
+@legacy_condition(six.text_type)
+@with_processor()
+def msg2subjective(msg, processor, subject, **config):
+    """ Return a human-readable text representation of a dict-like
+    fedmsg message from the subjective perspective of a user.
+
+    For example, if the subject viewing the message is "oddshocks"
+    and the message would normally translate into "oddshocks commented on
+    ticket #174", it would instead translate into "you commented on ticket
+    #174". """
+    fmt = u"{text} {link}"
+    text = processor.subjective(msg, **config)
+    link = processor.link(msg, **config) or ''
+    return fmt.format(**locals())

--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -310,9 +310,7 @@ def msg2subjective(msg, processor, subject, **config):
     and the message would normally translate into "oddshocks commented on
     ticket #174", it would instead translate into "you commented on ticket
     #174". """
-    fmt = u"{text} {link}"
     text = processor.subjective(msg, subject, **config)
     if not text:
         text = processor.subtitle(msg, **config)
-    link = processor.link(msg, **config) or ''
-    return fmt.format(**locals())
+    return text

--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -311,7 +311,7 @@ def msg2subjective(msg, processor, subject, **config):
     ticket #174", it would instead translate into "you commented on ticket
     #174". """
     fmt = u"{text} {link}"
-    text = processor.subjective(msg, **config)
+    text = processor.subjective(msg, subject, **config)
     if not text:
         text = processor.subtitle(msg, **config)
     link = processor.link(msg, **config) or ''

--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -302,7 +302,7 @@ def msg2avatars(msg, processor, **config):
 
 @legacy_condition(six.text_type)
 @with_processor()
-def msg2subjective(msg, processor, subject="", **config):
+def msg2subjective(msg, processor, subject, **config):
     """ Return a human-readable text representation of a dict-like
     fedmsg message from the subjective perspective of a user.
 

--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -302,7 +302,7 @@ def msg2avatars(msg, processor, **config):
 
 @legacy_condition(six.text_type)
 @with_processor()
-def msg2subjective(msg, processor, subject, **config):
+def msg2subjective(msg, processor, subject="", **config):
     """ Return a human-readable text representation of a dict-like
     fedmsg message from the subjective perspective of a user.
 

--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -312,5 +312,7 @@ def msg2subjective(msg, processor, subject, **config):
     #174". """
     fmt = u"{text} {link}"
     text = processor.subjective(msg, **config)
+    if not text:
+        text = processor.subtitle(msg, **config)
     link = processor.link(msg, **config) or ''
     return fmt.format(**locals())

--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -160,6 +160,10 @@ class BaseProcessor(object):
         """ Return a "subtitle" for the message. """
         return ""
 
+    def subjective(self, msg, subject, **config):
+        """ Return a "subjective" subtitle for the message. """
+        return ""
+
     def long_form(self, msg, **config):
         """ Return some paragraphs of text about a message. """
         return ""

--- a/fedmsg/meta/logger.py
+++ b/fedmsg/meta/logger.py
@@ -60,4 +60,4 @@ class LoggerProcessor(BaseProcessor):
         if msg['username'] == subject:
             tmpl = self._('you logged "{log}"')
             return tmpl.format(**msg['msg'])
-        return self.subtitle(msg, **config)
+        return None  # This causes our caller to default to using self.subtitle

--- a/fedmsg/meta/logger.py
+++ b/fedmsg/meta/logger.py
@@ -55,3 +55,9 @@ class LoggerProcessor(BaseProcessor):
         else:
             # *OLD* messages in datanommer's db don't have a username.
             return set()
+
+    def subjective(self, msg, subject, **config):
+        if msg['username'] == subject:
+            tmpl = self._('you logged "{log}"')
+            return tmpl.format(**msg['msg'])
+        return self.subtitle(msg, **config)

--- a/fedmsg/tests/test_meta.py
+++ b/fedmsg/tests/test_meta.py
@@ -212,10 +212,10 @@ class Base(unittest.TestCase):
     @skip_on(['msg', 'expected_subjective'])
     def test_subjective(self):
         """ Does fedmsg.meta produce the expected subjective message? """
-        subject = self.msg['msg']['user']['username']
-        actual_subjective = fedmsg.meta.msg2subjective(self.msg,
-                                                       subject, **self.config)
-        self._equals(actual_subjective, self.expected_subjective)
+        for subject, expected in self.expected_subjective.items():
+            actual_subjective = fedmsg.meta.msg2subjective(
+                self.msg, subject=subject, **self.config)
+            self._equals(actual_subjective, expected)
 
     @skip_on(['msg', 'expected_link'])
     def test_link(self):
@@ -297,6 +297,10 @@ class TestLoggerNormal(Base):
     expected_title = "logger.log"
     expected_subti = 'hello, world. (ralph)'
     expected_long_form = 'hello, world. (ralph)'
+    expected_subjective = {
+        'ralph': 'you logged "hello, world."',
+        'lmacken': expected_subti,
+    }
     expected_usernames = set(['ralph'])
 
     msg = {

--- a/fedmsg/tests/test_meta.py
+++ b/fedmsg/tests/test_meta.py
@@ -145,6 +145,7 @@ class Base(unittest.TestCase):
     msg = None
     expected_title = None
     expected_subti = None
+    expected_subjective = None
     expected_markup = None
     expected_link = None
     expected_icon = None
@@ -207,6 +208,12 @@ class Base(unittest.TestCase):
         """ Does fedmsg.meta produce the expected subtitle? """
         actual_subti = fedmsg.meta.msg2subtitle(self.msg, **self.config)
         self._equals(actual_subti, self.expected_subti)
+
+    @skip_on(['msg', 'expected_subjective'])
+    def test_subjective(self):
+        """ Does fedmsg.meta produce the expected subjective message? """
+        actual_subjective = fedmsg.meta.msg2subjective(self.msg, **self.config)
+        self._equals(actual_subjective, self.expected_subjective)
 
     @skip_on(['msg', 'expected_link'])
     def test_link(self):

--- a/fedmsg/tests/test_meta.py
+++ b/fedmsg/tests/test_meta.py
@@ -212,7 +212,9 @@ class Base(unittest.TestCase):
     @skip_on(['msg', 'expected_subjective'])
     def test_subjective(self):
         """ Does fedmsg.meta produce the expected subjective message? """
-        actual_subjective = fedmsg.meta.msg2subjective(self.msg, **self.config)
+        subject = self.msg['msg']['user']['username']
+        actual_subjective = fedmsg.meta.msg2subjective(self.msg,
+                                                       subject, **self.config)
         self._equals(actual_subjective, self.expected_subjective)
 
     @skip_on(['msg', 'expected_link'])


### PR DESCRIPTION
This will allow us to render messages in Fedora Hubs that instead of looking like:

  "ralph submitted a bodhi update for nethack"

can look like:

  "you submitted a bodhi update for nethack"