### PR TITLE
Reconcile the subjective API with the conglomerate API.

### DIFF
--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -157,7 +157,7 @@ def with_processor():
     return _wrapper
 
 
-def conglomerate(messages, **config):
+def conglomerate(messages, subject=None, **config):
     """ Return a list of messages with some of them grouped into conglomerate
     messages.  Conglomerate messages represent several other messages.
 
@@ -167,12 +167,15 @@ def conglomerate(messages, **config):
     messages, one representing the 38 git commit messages, one representing the
     bodhi.update message, and one representing the badge.award message.
 
+    The ``subject`` argument is optional and will return "subjective"
+    representations if possible (see msg2subjective(...)).
+
     Functionality is provided by fedmsg.meta plugins on a "best effort" basis.
     """
 
     # First, give every registered processor a chance to do its work
     for processor in processors:
-        messages = processor.conglomerate(messages, **config)
+        messages = processor.conglomerate(messages, subject=subject, **config)
 
     # Then, just fake it for every other ungrouped message.
     for i, message in enumerate(messages):
@@ -181,12 +184,14 @@ def conglomerate(messages, **config):
             continue
 
         # For ungrouped ones, replace them with a fake conglomerate
-        messages[i] = BaseConglomerator.produce_template([message], **config)
+        messages[i] = BaseConglomerator.produce_template(
+            [message], subject=subject, **config)
         # And fill out the fields that fully-implemented conglomerators would
         # normally fill out.
         messages[i].update({
             'link': msg2link(message, **config),
             'subtitle': msg2subtitle(message, **config),
+            'subjective': msg2subjective(message, subject=subject, **config),
             'secondary_icon': msg2secondary_icon(message, **config),
         })
 

--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -220,7 +220,7 @@ class BaseConglomerator(object):
         self.processor = processor
         self._ = internationalization_callable
 
-    def conglomerate(self, messages, **conf):
+    def conglomerate(self, messages, subject=None, **conf):
         """ Top-level API entry point.  Given a list of messages, transform it
         into a list of conglomerates where possible.
         """
@@ -228,7 +228,7 @@ class BaseConglomerator(object):
         while constituents:
             for idx in reversed(indices):
                 messages.pop(idx)
-            messages.insert(idx, self.merge(constituents, **conf))
+            messages.insert(idx, self.merge(constituents, subject, **conf))
             indices, constituents = self.select_constituents(messages, **conf)
 
         return messages
@@ -265,7 +265,7 @@ class BaseConglomerator(object):
         return None, None
 
     @classmethod
-    def produce_template(cls, constituents, **config):
+    def produce_template(cls, constituents, subject, **config):
         """ Helper function used by `merge`.
         Produces the beginnings of a merged conglomerate message that needs to
         be later filled out by a subclass.
@@ -299,6 +299,7 @@ class BaseConglomerator(object):
             (msg['msg_id'], {
                 'title': fm.msg2title(msg, **config),
                 'subtitle': fm.msg2subtitle(msg, **config),
+                'subjective': fm.msg2subjective(msg, subject=subject, **config),
                 'link': fm.msg2link(msg, **config),
                 'icon': fm.msg2icon(msg, **config),
                 'secondary_icon': fm.msg2secondary_icon(msg, **config),
@@ -362,6 +363,6 @@ class BaseConglomerator(object):
         pass
 
     @abc.abstractmethod
-    def merge(self, constituents, **config):
+    def merge(self, constituents, subject, **config):
         """ Given N presumably matching messages, return one merged message """
         pass

--- a/fedmsg/tests/test_meta.py
+++ b/fedmsg/tests/test_meta.py
@@ -362,7 +362,9 @@ class ConglomerateBase(unittest.TestCase):
     @skip_on(['originals', 'expected'])
     def test_conglomerate(self):
         """ Does fedmsg.meta produce the expected conglomeration? """
-        actual = fedmsg.meta.conglomerate(self.originals, **self.config)
+        subject = getattr(self, 'subject', None)
+        actual = fedmsg.meta.conglomerate(
+            self.originals, subject, **self.config)
 
         # Delete the msg_ids field because it is bulky and I don't want to
         # bother with testing it (copying and pasting it).


### PR DESCRIPTION
This should make it so you can pass an optional ``subject`` to the conglomerate
API and have it behave sensibly.

The subjective API allows you get a string like:

- "you submitted an update"

from a message where you would normally get a string like:

- "ralph submitted an update"

**If** you pass it a ``subject=ralph`` argument.

The conglomerate API allows you to group messages together and get single
strings that represent all of them.  So, instead of getting:

- "ralph submitted update X"
- "ralph submitted update Y"
- "ralph submitted update Z"

You get:

- "ralph submitted updates X, Y, and Z"

----

This patch reconciles those two APIs by letting the conglomerate functions
handle a ``subject`` if one is provided, so you can get something like:

- "you submitted updates X, Y, and Z"

This patch changes the conglomerate API and tests and requires a similar patch
provided in fedora-infra/fedmsg_meta_fedora_infrastructure#305.

This will be nice for the fedora-hubs implementation (eventually).