### PR TITLE
Isolate Moksha and cryptographic dependencies as extras

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
  - "3.4"
 
 install:
- - python setup.py install
+ - pip install -e .[hub]
  - pip install nose mock sqlalchemy unittest2
 script: nosetests -v
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
  - "3.4"
 
 install:
- - pip install -e .[hub]
+ - pip install -e .[all]
  - pip install nose mock sqlalchemy unittest2
 script: nosetests -v
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
  - "3.4"
 
 install:
- - pip install -e .[all]
+ - pip install -e .[commands,consumers]
  - pip install nose mock sqlalchemy unittest2
 script: nosetests -v
 notifications:

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,10 @@ fedmsg -- Fedora Messaging Client API
 .. split here
 
 Utilities used around Fedora Infrastructure to send and receive messages.
-Please see ``doc/`` or https://fedmsg.readthedocs.org/ for more info.
+Please see ``doc/`` or https://fedmsg.readthedocs.org/ for more info. Advanced
+functionality utilizes the Moksha framework, which is not included as a
+dependency by default. To install it along with all the commands which require
+it, install the 'full' extra (e.g., ``pip install fedmsg[full]``).
 
 Build Status
 ------------

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Utilities used around Fedora Infrastructure to send and receive messages.
 Please see ``doc/`` or https://fedmsg.readthedocs.org/ for more info. Advanced
 functionality utilizes the Moksha framework, which is not included as a
 dependency by default. To install it along with all the commands which require
-it, install the 'full' extra (e.g., ``pip install fedmsg[full]``).
+it, install the 'hub' extra (e.g., ``pip install fedmsg[hub]``).
 
 Build Status
 ------------

--- a/README.rst
+++ b/README.rst
@@ -4,10 +4,7 @@ fedmsg -- Fedora Messaging Client API
 .. split here
 
 Utilities used around Fedora Infrastructure to send and receive messages.
-Please see ``doc/`` or https://fedmsg.readthedocs.org/ for more info. Advanced
-functionality utilizes the Moksha framework, which is not included as a
-dependency by default. To install it along with all the commands which require
-it, install the 'hub' extra (e.g., ``pip install fedmsg[hub]``).
+Please see ``doc/`` or https://fedmsg.readthedocs.org/ for more info.
 
 Build Status
 ------------

--- a/doc/FAQ.rst
+++ b/doc/FAQ.rst
@@ -41,3 +41,36 @@ Frequently Asked Questions
     fedmsg-tail, please report it in the ``#fedora-apps`` IRC channel or
     as a `ticket on github
     <https://github.com/fedora-infra/fedmsg/issues/new>`_.
+
+- I tried installing the ``crypto`` extra but got an error about
+  something called "swig" during the ``M2Crypto`` installation.
+
+  - If you try to install fedmsg from the Python sources (including
+    PyPI), then installation may fail with an error message resembling
+    the following::
+
+        ...
+        error: command 'swig' failed with exit status 1
+        ...
+
+    This happens because the ``M2Crypto`` dependency of fedmsg requires
+    the non-Python package ``swig`` during it's compilation process.
+    Since this can't be readily expressed from within the Python
+    ecosystem, the setup script (unfortunately) just assumes that it's
+    present.
+
+    The easiest way to avoid this problem is to install fedmsg using
+    your system package manager (*e.g.*, ``dnf install fedmsg``). This
+    is the recommended way to get fedmsg and has a much higher chance
+    of working (if it doesn't, then the package is likely broken, and
+    the maintainer(s) will want to know about that).
+
+    If you have a specific reason to want to install fedmsg from
+    source, then installing ``M2Crypto`` with you system package
+    manager (the package is likely called something along the lines of
+    ``python-m2crypto``) should satisfy the requirement and allow
+    fedmsg to successfully install.  If you're unlucky and your distro
+    doesn't have a packaged version of ``M2Crypto``, then installing
+    ``swig`` (which is just called plain ``swig`` in most package
+    repositories) should allow ``pip`` to successfully build
+    ``M2Crypto`` itself during the installation of fedmsg.

--- a/doc/FAQ.rst
+++ b/doc/FAQ.rst
@@ -43,7 +43,7 @@ Frequently Asked Questions
     <https://github.com/fedora-infra/fedmsg/issues/new>`_.
 
 - I tried installing the ``crypto`` extra but got an error about
-  something called "swig" during the ``M2Crypto`` installation.
+  something called "swig" during the M2Crypto installation.
 
   - If you try to install fedmsg from the Python sources (including
     PyPI), then installation may fail with an error message resembling
@@ -53,24 +53,22 @@ Frequently Asked Questions
         error: command 'swig' failed with exit status 1
         ...
 
-    This happens because the ``M2Crypto`` dependency of fedmsg requires
-    the non-Python package ``swig`` during it's compilation process.
-    Since this can't be readily expressed from within the Python
-    ecosystem, the setup script (unfortunately) just assumes that it's
-    present.
+    This happens because the M2Crypto dependency of fedmsg requires the
+    non-Python package "swig" during it's compilation process.  Since
+    this can't be readily expressed from within the Python ecosystem,
+    the setup script (unfortunately) just assumes that it's present.
 
     The easiest way to avoid this problem is to install fedmsg using
     your system package manager (*e.g.*, ``dnf install fedmsg``). This
     is the recommended way to get fedmsg and has a much higher chance
-    of working (if it doesn't, then the package is likely broken, and
-    the maintainer(s) will want to know about that).
+    of working. (If it doesn't, then the package is likely broken, and
+    the maintainer(s) will want to know about that.)
 
     If you have a specific reason to want to install fedmsg from
-    source, then installing ``M2Crypto`` with you system package
-    manager (the package is likely called something along the lines of
+    source, then installing M2Crypto with you system package manager
+    (the package is likely called something along the lines of
     ``python-m2crypto``) should satisfy the requirement and allow
     fedmsg to successfully install.  If you're unlucky and your distro
-    doesn't have a packaged version of ``M2Crypto``, then installing
-    ``swig`` (which is just called plain ``swig`` in most package
-    repositories) should allow ``pip`` to successfully build
-    ``M2Crypto`` itself during the installation of fedmsg.
+    doesn't have a packaged version of M2Crypto, then installing swig
+    (which is just called plain ``swig`` in most package repositories)
+    should allow M2Crypto to build successfully.

--- a/doc/FAQ.rst
+++ b/doc/FAQ.rst
@@ -27,7 +27,7 @@ Frequently Asked Questions
   - Is the formatting just different?  Try the following to get those "nice"
     messages::
 
-        $ sudo yum install python-fedmsg-meta-fedora-infrastructure
+        $ sudo dnf install python-fedmsg-meta-fedora-infrastructure
         $ fedmsg-tail --terse
 
   - What you were seeing before was the raw JSON content of the messages.

--- a/doc/consuming.rst
+++ b/doc/consuming.rst
@@ -45,6 +45,10 @@ and maintain.
 For production services, you will want to use the hub-consumer approach
 described further below.
 
+.. note:: If you installed fedmsg from PyPI (or source), make sure that
+   you've installed the 'consumers' extra, which may be done like so:
+   ``pip install fedmsg[consumers]``.
+
 Note that the :func:`fedmsg.tail_messages` used to be quite inefficient;
 it spun in a sleep, listen, yield loop that was quite costly in IO and CPU
 terms.  Typically, a script that used :func:`fedmsg.tail_messages` would

--- a/doc/deployment.rst
+++ b/doc/deployment.rst
@@ -28,7 +28,7 @@ The basics
 
 First install fedmsg::
 
-    $ sudo yum install fedmsg
+    $ sudo dnf install fedmsg
 
 Now you have some ``fedmsg-*`` cli tools like ``fedmsg-tail`` and
 ``fedmsg-logger``.
@@ -53,7 +53,7 @@ terminal does.
 
 Install fedmsg-relay and start it::
 
-    $ sudo yum install fedmsg-relay
+    $ sudo dnf install fedmsg-relay
     $ sudo systemctl restart fedmsg-relay
     $ sudo systemctl enable fedmsg-relay
 
@@ -158,7 +158,7 @@ Setting up postgres
 
 Here, set up a postgres database::
 
-    $ sudo yum install postgresql-server python-psycopg2
+    $ sudo dnf install postgresql-server python-psycopg2
     $ postgresql-setup initdb
 
 Edit the ``/var/lib/pgsql/data/pg_hba.conf`` as the user postgres. You might
@@ -193,7 +193,7 @@ Setting up datanommer
 
 Install it::
 
-    $ sudo yum install fedmsg-hub python-datanommer-consumer datanommer-commands
+    $ sudo dnf install fedmsg-hub python-datanommer-consumer datanommer-commands
 
 Edit the configuration to 1) be enabled, 2) point at your newly created
 postgres db.  Edit ``/etc/fedmsg.d/datanommer.py`` and change the whole thing
@@ -234,7 +234,7 @@ You can, of course, query datanommer with SQL yourself (and there's a python
 API for directly querying in the ``datanommer.models`` module).  For the rest
 here is the HTTP API we have called "datagrepper".  Let's set it up::
 
-    $ sudo yum install datagrepper mod_wsgi
+    $ sudo dnf install datagrepper mod_wsgi
 
 Add a config file for it in ``/etc/httpd/conf.d/datagrepper.conf`` with these contents::
 
@@ -268,7 +268,7 @@ And it should just work.  Open a web browser and try to visit
 The whole point of datagrepper is its API, which you might experiment with
 using the httpie tool::
 
-    $ sudo yum install httpie
+    $ sudo dnf install httpie
     $ http get http://localhost/datagrepper/raw/ order==desc
 
 Outro

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -14,19 +14,19 @@ using that.
 
 You can install it with::
 
-    $ sudo yum install python-virtualenvwrapper
+    $ sudo dnf install python-virtualenvwrapper
 
 .. note:: If you decide not to use python-virtualenvwrapper, you can always use
    latest update of fedmsg in fedora.  If you are doing this, simply ignore all
    ``mkvirtualenv`` and ``workon`` commands in these instructions.  You can
-   install fedmsg with ``sudo yum install fedmsg``.
+   install fedmsg with ``sudo dnf install fedmsg``.
 
 Development Dependencies
 ------------------------
 
 Get::
 
-    $ sudo yum install python-virtualenv openssl-devel zeromq-devel gcc
+    $ sudo dnf install python-virtualenv openssl-devel zeromq-devel gcc
 
 Cloning the Upstream Git Repo
 -----------------------------

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -50,26 +50,20 @@ Create a new, empty virtualenv and install all the dependencies from `pypi
 
     $ cd fedmsg
     $ mkvirtualenv fedmsg
-    (fedmsg)$ python setup.py develop
+    (fedmsg)$ pip install -e .[all]
 
 .. note::  If the mkvirtualenv command is unavailable try
    ``source /usr/bin/virtualenvwrapper.sh`` on Fedora (if you do not run Fedora
    you might have to adjust the command a little).
 
-You should also run the tests, just to make sure everything is sane::
-
-    (fedmsg)$ python setup.py test
-
-If you'd like to install the extra dependencies (recommended for development;
-otherwise, not all commands will be functional), then you can use this
-command::
-
-    (fedmsg)$ pip install -e .[all]
-
 .. note::  As discussed in the FAQ, M2Crypto requires the swig command to be
    available in order to build successfully.  It's recommended that you
    install M2Crypto using your system package manager, which can be done with
    ``dnf install python-m2crypto`` on Fedora.
+
+You should also run the tests, just to make sure everything is sane::
+
+    (fedmsg)$ python setup.py test
 
 Try out the shell commands
 --------------------------

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -60,6 +60,17 @@ You should also run the tests, just to make sure everything is sane::
 
     (fedmsg)$ python setup.py test
 
+If you'd like to install the extra dependencies (recommended for development;
+otherwise, not all commands will be functional), then you can use this
+command::
+
+    (fedmsg)$ pip install -e .[all]
+
+.. note::  As discussed in the FAQ, M2Crypto requires the swig command to be
+   available in order to build successfully.  It's recommended that you
+   install M2Crypto using your system package manager, which can be done with
+   ``dnf install python-m2crypto`` on Fedora.
+
 Try out the shell commands
 --------------------------
 

--- a/fedmsg/commands/tail.py
+++ b/fedmsg/commands/tail.py
@@ -100,6 +100,21 @@ class TailCommand(BaseCommand):
             'help': 'A comma-separated list of packages.  Show only messages'
             'related to these packages.',
         }),
+        (['--validate'], {
+            'dest': 'validate_signatures',
+            'default': None,
+            'help': 'Override the \'validate_signatures\' configuration value'
+            'to be True so that X509 certificates in messages are validated.',
+            'action': 'store_true',
+        }),
+        (['--no-validate'], {
+            'dest': 'validate_signatures',
+            'default': None,
+            'help': 'Override the \'validate_signatures\' configuration value'
+            'to be False so that X509 certificates in messages are ignored.',
+            'action': 'store_false',
+        }),
+
     ]
 
     def run(self):

--- a/fedmsg/core.py
+++ b/fedmsg/core.py
@@ -361,7 +361,6 @@ class FedMsgContext(object):
         for subscriber in subs:
             poller.register(subscriber, zmq.POLLIN)
 
-        # TODO -- what if user wants to pass in validate_signatures in **kw?
         validate = self.c.get('validate_signatures', False)
 
         # Poll that poller.  This is much more efficient than it used to be.

--- a/setup.py
+++ b/setup.py
@@ -169,8 +169,8 @@ setup(
         ],
         # fedmsg core only provides one metadata provider.
         'fedmsg.meta': [
-            "logger=fedmsg.meta.logger:LoggerProcessor [full]",
-            "announce=fedmsg.meta.announce:AnnounceProcessor [full]",
+            "logger=fedmsg.meta.logger:LoggerProcessor",
+            "announce=fedmsg.meta.announce:AnnounceProcessor",
         ],
     },
     **data_config

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,15 @@ extras_require = {
         'cryptography',    # for message signing
     ],
 }
+extras_require['all'] = [
+    requirement
+    for requirements in extras_require.values()
+    for requirement in requirements
+]
+extras_require['all'].extend([
+    'daemon',
+    'arrow',
+])
 tests_require = [
     'nose',
     'sqlalchemy',  # For the persistent-store test(s).

--- a/setup.py
+++ b/setup.py
@@ -170,10 +170,10 @@ setup(
             "fedmsg-irc=fedmsg.commands.ircbot:ircbot [consumers]",
         ],
         'moksha.consumer': [
-            "fedmsg-dummy=fedmsg.consumers.dummy:DummyConsumer [consumers]", # require moksha.hub
-            "fedmsg-relay=fedmsg.consumers.relay:RelayConsumer [consumers]", # require moksha.hub
-            "fedmsg-gateway=fedmsg.consumers.gateway:GatewayConsumer [consumers]", # require moksha.hub
-            "fedmsg-ircbot=fedmsg.consumers.ircbot:IRCBotConsumer [consumers]", # require moksha.hub
+            "fedmsg-dummy=fedmsg.consumers.dummy:DummyConsumer [consumers]",
+            "fedmsg-relay=fedmsg.consumers.relay:RelayConsumer [consumers]",
+            "fedmsg-gateway=fedmsg.consumers.gateway:GatewayConsumer [consumers]",
+            "fedmsg-ircbot=fedmsg.consumers.ircbot:IRCBotConsumer [consumers]",
         ],
         'moksha.producer': [
         ],

--- a/setup.py
+++ b/setup.py
@@ -79,12 +79,12 @@ extras_require = {
         'm2ext',       # for message validation
     ],
     'commands': [
-        'daemon',      # not *necessarily* required
         'pygments',
         'psutil',
     ],
     'consumers': [
         'moksha.hub>=1.3.0',
+        'daemon',      # not *necessarily* required
         'pygments',
         'psutil',
     ],

--- a/setup.py
+++ b/setup.py
@@ -73,15 +73,16 @@ install_requires = [
     #'daemon',
     'psutil',
     #'arrow',  # This is actually optional.
-
-    # These are "optional" for now to make installation from pypi easier.
-    #'M2Crypto',        # for message validation
-    #'m2ext',           # for message validation
-    #'cryptography',    # for message signing
 ]
 extras_require = {
     'full': [
         'moksha.hub>=1.3.0',
+    ],
+    'crypto': [
+        # These are "optional" for now to make installation from pypi easier.
+        'M2Crypto',        # for message validation
+        'm2ext',           # for message validation
+        'cryptography',    # for message signing
     ],
 }
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ except Exception:
 install_requires = [
     'pyzmq',
     'kitchen',
-    'moksha.hub>=1.3.0',
     'requests',
     'pygments',
     'six',
@@ -80,6 +79,11 @@ install_requires = [
     #'m2ext',           # for message validation
     #'cryptography',    # for message signing
 ]
+extras_require = {
+    'full': [
+        'moksha.hub>=1.3.0',
+    ],
+}
 tests_require = [
     'nose',
     'sqlalchemy',  # For the persistent-store test(s).
@@ -107,6 +111,7 @@ setup(
     url='https://github.com/fedora-infra/fedmsg/',
     license='LGPLv2+',
     install_requires=install_requires,
+    extras_require=extras_require,
     tests_require=tests_require,
     test_suite='nose.collector',
     packages=[
@@ -142,30 +147,30 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            "fedmsg-logger=fedmsg.commands.logger:logger",
+            "fedmsg-logger=fedmsg.commands.logger:logger [full]",
             "fedmsg-tail=fedmsg.commands.tail:tail",
-            "fedmsg-hub=fedmsg.commands.hub:hub",
-            "fedmsg-relay=fedmsg.commands.relay:relay",
-            "fedmsg-gateway=fedmsg.commands.gateway:gateway",
+            "fedmsg-hub=fedmsg.commands.hub:hub [full]",
+            "fedmsg-relay=fedmsg.commands.relay:relay [full]",
+            "fedmsg-gateway=fedmsg.commands.gateway:gateway [full]",
             #"fedmsg-config=fedmsg.commands.config:config",
-            "fedmsg-irc=fedmsg.commands.ircbot:ircbot",
-            "fedmsg-collectd=fedmsg.commands.collectd:collectd",
+            "fedmsg-irc=fedmsg.commands.ircbot:ircbot [full]",
+            "fedmsg-collectd=fedmsg.commands.collectd:collectd [full]",
             "fedmsg-announce=fedmsg.commands.announce:announce",
             "fedmsg-trigger=fedmsg.commands.trigger:trigger",
             "fedmsg-dg-replay=fedmsg.commands.replay:replay",
         ],
         'moksha.consumer': [
-            "fedmsg-dummy=fedmsg.consumers.dummy:DummyConsumer",
-            "fedmsg-relay=fedmsg.consumers.relay:RelayConsumer",
-            "fedmsg-gateway=fedmsg.consumers.gateway:GatewayConsumer",
-            "fedmsg-ircbot=fedmsg.consumers.ircbot:IRCBotConsumer",
+            "fedmsg-dummy=fedmsg.consumers.dummy:DummyConsumer [full]",
+            "fedmsg-relay=fedmsg.consumers.relay:RelayConsumer [full]",
+            "fedmsg-gateway=fedmsg.consumers.gateway:GatewayConsumer [full]",
+            "fedmsg-ircbot=fedmsg.consumers.ircbot:IRCBotConsumer [full]",
         ],
         'moksha.producer': [
         ],
         # fedmsg core only provides one metadata provider.
         'fedmsg.meta': [
-            "logger=fedmsg.meta.logger:LoggerProcessor",
-            "announce=fedmsg.meta.announce:AnnounceProcessor",
+            "logger=fedmsg.meta.logger:LoggerProcessor [full]",
+            "announce=fedmsg.meta.announce:AnnounceProcessor [full]",
         ],
     },
     **data_config

--- a/setup.py
+++ b/setup.py
@@ -89,11 +89,11 @@ extras_require = {
         'psutil',
     ],
 }
-extras_require['all'] = list({
+extras_require['all'] = list(set(
     requirement
     for requirements in extras_require.values()
     for requirement in requirements
-})
+))
 tests_require = [
     'nose',
     'sqlalchemy',  # For the persistent-store test(s).

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ if sys.version_info[0] == 2:
 
 setup(
     name='fedmsg',
-    version='0.15.0',
+    version='0.15.1',
     description="Fedora Messaging Client API",
     long_description=long_description,
     author='Ralph Bean',

--- a/setup.py
+++ b/setup.py
@@ -68,30 +68,32 @@ install_requires = [
     'pyzmq',
     'kitchen',
     'requests',
-    'pygments',
     'six',
-    'psutil',
+    'arrow',           # not *necessarily* required
+    'cryptography',    # for message signing
 ]
 extras_require = {
-    'hub': [
-        'moksha.hub>=1.3.0',
-    ],
     'crypto': [
         # These are "optional" for now to make installation from pypi easier.
-        'M2Crypto',        # for message validation
-        'm2ext',           # for message validation
-        'cryptography',    # for message signing
+        'M2Crypto',    # for message validation
+        'm2ext',       # for message validation
+    ],
+    'commands': [
+        'daemon',      # not *necessarily* required
+        'pygments',
+        'psutil',
+    ],
+    'consumers': [
+        'moksha.hub>=1.3.0',
+        'pygments',
+        'psutil',
     ],
 }
-extras_require['all'] = [
+extras_require['all'] = list({
     requirement
     for requirements in extras_require.values()
     for requirement in requirements
-]
-extras_require['all'].extend([
-    'daemon',
-    'arrow',
-])
+})
 tests_require = [
     'nose',
     'sqlalchemy',  # For the persistent-store test(s).
@@ -155,23 +157,23 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            "fedmsg-logger=fedmsg.commands.logger:logger [hub]",
-            "fedmsg-tail=fedmsg.commands.tail:tail",
-            "fedmsg-hub=fedmsg.commands.hub:hub [hub]",
-            "fedmsg-relay=fedmsg.commands.relay:relay [hub]",
-            "fedmsg-gateway=fedmsg.commands.gateway:gateway [hub]",
-            #"fedmsg-config=fedmsg.commands.config:config",
-            "fedmsg-irc=fedmsg.commands.ircbot:ircbot [hub]",
-            "fedmsg-collectd=fedmsg.commands.collectd:collectd [hub]",
-            "fedmsg-announce=fedmsg.commands.announce:announce",
-            "fedmsg-trigger=fedmsg.commands.trigger:trigger",
-            "fedmsg-dg-replay=fedmsg.commands.replay:replay",
+            "fedmsg-logger=fedmsg.commands.logger:logger [commands]",
+            "fedmsg-tail=fedmsg.commands.tail:tail [commands]",
+            "fedmsg-collectd=fedmsg.commands.collectd:collectd [commands]",
+            "fedmsg-announce=fedmsg.commands.announce:announce [commands]",
+            "fedmsg-trigger=fedmsg.commands.trigger:trigger [commands]",
+            "fedmsg-dg-replay=fedmsg.commands.replay:replay [commands]",
+            #"fedmsg-config=fedmsg.commands.config:config [commands]",
+            "fedmsg-hub=fedmsg.commands.hub:hub [consumers]",
+            "fedmsg-relay=fedmsg.commands.relay:relay [consumers]",
+            "fedmsg-gateway=fedmsg.commands.gateway:gateway [consumers]",
+            "fedmsg-irc=fedmsg.commands.ircbot:ircbot [consumers]",
         ],
         'moksha.consumer': [
-            "fedmsg-dummy=fedmsg.consumers.dummy:DummyConsumer [hub]",
-            "fedmsg-relay=fedmsg.consumers.relay:RelayConsumer [hub]",
-            "fedmsg-gateway=fedmsg.consumers.gateway:GatewayConsumer [hub]",
-            "fedmsg-ircbot=fedmsg.consumers.ircbot:IRCBotConsumer [hub]",
+            "fedmsg-dummy=fedmsg.consumers.dummy:DummyConsumer [consumers]", # require moksha.hub
+            "fedmsg-relay=fedmsg.consumers.relay:RelayConsumer [consumers]", # require moksha.hub
+            "fedmsg-gateway=fedmsg.consumers.gateway:GatewayConsumer [consumers]", # require moksha.hub
+            "fedmsg-ircbot=fedmsg.consumers.ircbot:IRCBotConsumer [consumers]", # require moksha.hub
         ],
         'moksha.producer': [
         ],

--- a/setup.py
+++ b/setup.py
@@ -70,12 +70,10 @@ install_requires = [
     'requests',
     'pygments',
     'six',
-    #'daemon',
     'psutil',
-    #'arrow',  # This is actually optional.
 ]
 extras_require = {
-    'full': [
+    'hub': [
         'moksha.hub>=1.3.0',
     ],
     'crypto': [
@@ -148,23 +146,23 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            "fedmsg-logger=fedmsg.commands.logger:logger [full]",
+            "fedmsg-logger=fedmsg.commands.logger:logger [hub]",
             "fedmsg-tail=fedmsg.commands.tail:tail",
-            "fedmsg-hub=fedmsg.commands.hub:hub [full]",
-            "fedmsg-relay=fedmsg.commands.relay:relay [full]",
-            "fedmsg-gateway=fedmsg.commands.gateway:gateway [full]",
+            "fedmsg-hub=fedmsg.commands.hub:hub [hub]",
+            "fedmsg-relay=fedmsg.commands.relay:relay [hub]",
+            "fedmsg-gateway=fedmsg.commands.gateway:gateway [hub]",
             #"fedmsg-config=fedmsg.commands.config:config",
-            "fedmsg-irc=fedmsg.commands.ircbot:ircbot [full]",
-            "fedmsg-collectd=fedmsg.commands.collectd:collectd [full]",
+            "fedmsg-irc=fedmsg.commands.ircbot:ircbot [hub]",
+            "fedmsg-collectd=fedmsg.commands.collectd:collectd [hub]",
             "fedmsg-announce=fedmsg.commands.announce:announce",
             "fedmsg-trigger=fedmsg.commands.trigger:trigger",
             "fedmsg-dg-replay=fedmsg.commands.replay:replay",
         ],
         'moksha.consumer': [
-            "fedmsg-dummy=fedmsg.consumers.dummy:DummyConsumer [full]",
-            "fedmsg-relay=fedmsg.consumers.relay:RelayConsumer [full]",
-            "fedmsg-gateway=fedmsg.consumers.gateway:GatewayConsumer [full]",
-            "fedmsg-ircbot=fedmsg.consumers.ircbot:IRCBotConsumer [full]",
+            "fedmsg-dummy=fedmsg.consumers.dummy:DummyConsumer [hub]",
+            "fedmsg-relay=fedmsg.consumers.relay:RelayConsumer [hub]",
+            "fedmsg-gateway=fedmsg.consumers.gateway:GatewayConsumer [hub]",
+            "fedmsg-ircbot=fedmsg.consumers.ircbot:IRCBotConsumer [hub]",
         ],
         'moksha.producer': [
         ],


### PR DESCRIPTION
I found [this semi-ancient issue](https://github.com/fedora-infra/fedmsg/issues/121), and thought it would be a good way to get to know fedmsg better. If it's not relevant anymore, feel free to close out this pull request.

What I've done is split off the non-essential dependencies of fedmsg into what setuptools calls "extras." These are not installed by default but require a command such as ``pip install fedmsg[crypto]``. These allow us to communicate optional dependencies to users. I've created three extras: 'hub', for Moksha and all its dependencies; 'crypto', for the semi-essential cryptographic libraries; and 'all', which is the auto-generated sum of the prior two, plus two other packages which had been previously indicated as non-essential. (It's possible that I misunderstood that role of those two packages, ``daemon`` and ``arrow``, so please correct me if I'm wrong.) As many of the fedmsg commands require the presence of Moksha, I've flagged those entry-points in a manner that setuptools and ``pip`` both understand.

In working on fedmsg, I noticed that ``fedmsg-tail`` doesn't actually work out of the box without M2Crypto. I saw that there were prior plans to add command-line arguments to override the need for it, and I went ahead and implemented them as ``--validate`` and ``--no-validate`` (if a parameter of the form ``--validate=[true|false]`` is preferable, I can easily change that). This is somewhat tangential to the primary feature targeted by this pull request, and I can split it off for separate review if so desired.

Aside from all that, I've also updated the documentation accordingly (I think I've found all places where these changes would be relevant) and bumped up the version number by a minor point.