### PR TITLE
Add a new msg2agent API call to fedmsg.meta.

### DIFF
--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -278,6 +278,36 @@ def msg2usernames(msg, processor=None, legacy=False, **config):
     return processor.usernames(msg, **config)
 
 
+@with_processor()
+def msg2agent(msg, processor=None, legacy=False, **config):
+    """ Return the single username who is the "agent" for an event.
+
+    An "agent" is the one responsible for the event taking place, for example,
+    if one person gives karma to another, then both usernames are returned by
+    msg2usernames, but only the one who gave the karma is returned by
+    msg2agent.
+
+    If the processor registered to handle the message does not provide an
+    agent method, then the *first* user returned by msg2usernames is returned
+    (whether that is correct or not).  Here we assume that if a processor
+    implements `agent`, then it knows what it is doing and we should trust
+    that.  But if it does not implement it, we'll try our best guess.
+
+    If there are no users returned by msg2usernames, then None is returned.
+    """
+
+    if not processor.agent is NotImplemented:
+        return processor.agent(msg, **config)
+    else:
+        usernames = processor.usernames(msg, **config)
+        # usernames is a set(), which doesn't support indexing.
+        if usernames:
+            return usernames.pop()
+
+    # default to None if we can't find anything
+    return None
+
+
 @legacy_condition(set)
 @with_processor()
 def msg2packages(msg, processor, **config):

--- a/fedmsg/meta/announce.py
+++ b/fedmsg/meta/announce.py
@@ -38,3 +38,8 @@ class AnnounceProcessor(BaseProcessor):
         if 'username' in msg:
             users.update(set([msg['username']]))
         return users
+
+    def agent(self, msg, **config):
+        if 'username' in msg:
+            return msg['username']
+        return None

--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -183,6 +183,12 @@ class BaseProcessor(object):
         """ Return a set of FAS usernames associated with a message. """
         return set()
 
+    # XXX - this is intentionally not stubbed out at the 'base' level of the
+    # class inheritance hierarchy.  In fedmsg/meta/__init__.py, we check for
+    # the existance of this method on the subclass and do something special if
+    # it is absent (if it is unimplemented by the subclass).
+    agent = NotImplemented
+
     def packages(self, msg, **config):
         """ Return a set of package names associated with a message. """
         return set()

--- a/fedmsg/meta/logger.py
+++ b/fedmsg/meta/logger.py
@@ -56,6 +56,11 @@ class LoggerProcessor(BaseProcessor):
             # *OLD* messages in datanommer's db don't have a username.
             return set()
 
+    def agent(self, msg, **config):
+        if 'username' in msg:
+            return msg['username']
+        return None
+
     def subjective(self, msg, subject, **config):
         if msg['username'] == subject:
             tmpl = self._('you logged "{log}"')

--- a/fedmsg/tests/test_meta.py
+++ b/fedmsg/tests/test_meta.py
@@ -36,15 +36,23 @@ except ImportError:
 import fedmsg.meta
 
 
+class UnspecifiedType(object):
+    """ A sentinel used to identify which expectations are not specified. """
+    pass
+
+
+Unspecified = UnspecifiedType()
+
+
 def skip_on(attributes):
     """ A test decorator that will skip if any of the named attributes
-    are left unspecified (are None-valued).
+    are left unspecified.
     """
     def wrapper(func):
         @make_decorator(func)
         def inner(self):
             for attr in attributes:
-                if getattr(self, attr) is None:
+                if getattr(self, attr) is Unspecified:
                     raise SkipTest("%r left unspecified" % attr)
             return func(self)
         return inner
@@ -143,20 +151,21 @@ class TestProcessorRegex(unittest.TestCase):
 
 
 class Base(unittest.TestCase):
-    msg = None
-    expected_title = None
-    expected_subti = None
-    expected_subjective = None
-    expected_markup = None
-    expected_link = None
-    expected_icon = None
-    expected_secondary_icon = None
-    expected_usernames = None
-    expected_packages = None
-    expected_objects = None
-    expected_emails = None
-    expected_avatars = None
-    expected_long_form = None
+    msg = Unspecified
+    expected_title = Unspecified
+    expected_subti = Unspecified
+    expected_subjective = Unspecified
+    expected_markup = Unspecified
+    expected_link = Unspecified
+    expected_icon = Unspecified
+    expected_secondary_icon = Unspecified
+    expected_usernames = Unspecified
+    expected_agent = Unspecified
+    expected_packages = Unspecified
+    expected_objects = Unspecified
+    expected_emails = Unspecified
+    expected_avatars = Unspecified
+    expected_long_form = Unspecified
 
     def setUp(self):
         dirname = os.path.abspath(os.path.dirname(__file__))
@@ -345,8 +354,8 @@ class TestLoggerJSON(Base):
 
 
 class ConglomerateBase(unittest.TestCase):
-    originals = None
-    expected = None
+    originals = Unspecified
+    expected = Unspecified
     maxDiff = None
 
     def setUp(self):
@@ -361,7 +370,7 @@ class ConglomerateBase(unittest.TestCase):
 
         # Delete the msg_ids field because it is bulky and I don't want to
         # bother with testing it (copying and pasting it).
-        if self.expected:
+        if not self.expected is Unspecified:
             for item in self.expected:
                 if 'msg_ids' in item:
                     del item['msg_ids']

--- a/fedmsg/tests/test_meta.py
+++ b/fedmsg/tests/test_meta.py
@@ -296,6 +296,7 @@ class TestAnnouncement(Base):
     expected_long_form = 'hello, world.'
     expected_link = 'foo'
     expected_usernames = set(['ralph'])
+    expected_agent = 'ralph'
 
     msg = {
         "i": 1,
@@ -318,6 +319,7 @@ class TestLoggerNormal(Base):
         'lmacken': expected_subti,
     }
     expected_usernames = set(['ralph'])
+    expected_agent = 'ralph'
 
     msg = {
         "i": 1,
@@ -341,6 +343,7 @@ class TestLoggerJSON(Base):
         }
     """).strip()
     expected_usernames = set(['root'])
+    expected_agent = 'root'
 
     msg = {
         "i": 1,

--- a/fedmsg/tests/test_meta.py
+++ b/fedmsg/tests/test_meta.py
@@ -242,6 +242,12 @@ class Base(unittest.TestCase):
         actual_usernames = fedmsg.meta.msg2usernames(self.msg, **self.config)
         self._equals(actual_usernames, self.expected_usernames)
 
+    @skip_on(['msg', 'expected_agent'])
+    def test_agent(self):
+        """ Does fedmsg.meta produce the expected agent? """
+        actual_agent = fedmsg.meta.msg2agent(self.msg, **self.config)
+        self._equals(actual_agent, self.expected_agent)
+
     @skip_on(['msg', 'expected_packages'])
     def test_packages(self):
         """ Does fedmsg.meta produce the expected list of packages? """


### PR DESCRIPTION
As the docstrings indicate, this is different from msg2usernames.

- msg2usernames returns *all* of the users associated with a message and
  doesn't distinguish their particular relationships with the event.

- This new msg2agent will return *just* the user who is responsible for the
  event.  So, in the case of one user giving karma to another, both users will
  be returned by msg2usernames, but just the one who gave the karma will be
  returned by msg2agent.

Furthermore, this pull request changes the test framework to allow testing None values.

Previously, if the ``expected_{value}`` on a test was set to ``None``, then
that test would be skipped.  However, that didn't allow us to test that a
value returned *really was None* or not.

This change introduces the use of a sentinel value called ``Unspecified``
that we use instead of ``None`` so that we can now set a test to ``None``
over in fedmsg_meta_fedora_infrastructure and find out if the actual value
returned by our code really was None or not.