### PR TITLE
Try three times to get the CRL.

### DIFF
--- a/fedmsg/crypto/x509.py
+++ b/fedmsg/crypto/x509.py
@@ -230,7 +230,7 @@ def validate(message, ssldir=None, **config):
     return True
 
 
-def _load_remote_cert(location, cache, cache_expiry, **config):
+def _load_remote_cert(location, cache, cache_expiry, tries=0, **config):
     """ Get a fresh copy from fp.o/fedmsg/crl.pem if ours is getting stale.
 
     Return the local filename.
@@ -251,8 +251,14 @@ def _load_remote_cert(location, cache, cache_expiry, **config):
             with open(cache, 'w') as f:
                 f.write(response.content)
         except requests.exceptions.ConnectionError:
-            log.error("Could not access %r" % location)
-            raise
+            if tries < 3:
+                log.warn("Could not access %r.  Trying again." % location)
+                time.sleep(1)  # Take a nap to see if the network settles down.
+                return _load_remote_cert(
+                    location, cache, cache_expiry, tries+1, **config)
+            else:
+                log.error("Could not access %r" % location)
+                raise
         except IOError as e:
             # If we couldn't write to the specified cache location, try a
             # similar place but inside our home directory instead.


### PR DESCRIPTION
I've gotten reports from multiple people in recent weeks that their fedmsg
scripts fail and exit when *something happens* and they are unable to pull down
the CRL.  We're not sure why that's failing yet.  It may be a network blip, or
it may be a proxy issue.  In the meantime, we can make fedmsg try a little
harder to get that file before it blows up on the user.