### PR TITLE
Stick with alternative cache location.

### DIFF
--- a/fedmsg/crypto/x509.py
+++ b/fedmsg/crypto/x509.py
@@ -235,12 +235,20 @@ def _load_remote_cert(location, cache, cache_expiry, tries=0, **config):
 
     Return the local filename.
     """
+    alternative_cache = os.path.expanduser("~/.local" + cache)
 
     try:
         modtime = os.stat(cache).st_mtime
     except OSError:
         # File does not exist yet.
-        modtime = 0
+        try:
+            # Try alternative location.
+            modtime = os.stat(alternative_cache).st_mtime
+            # It worked!  Use the alternative location
+            cache = alternative_cache
+        except OSError:
+            # Neither file exists
+            modtime = 0
 
     if (
         (not modtime and not cache_expiry) or
@@ -262,7 +270,7 @@ def _load_remote_cert(location, cache, cache_expiry, tries=0, **config):
         except IOError as e:
             # If we couldn't write to the specified cache location, try a
             # similar place but inside our home directory instead.
-            cache = os.path.expanduser("~/.local" + cache)
+            cache = alternative_cache
             usr_dir = '/'.join(cache.split('/')[:-1])
 
             if not os.path.isdir(usr_dir):


### PR DESCRIPTION
Here's the story:

- When we validate an incoming message, we try to check that it is signed with
  our CA and that it is not in our CRL.
- When we do that, we check our local cache of those files.  If they are too
  old, we grab them fresh from ``https://fedoraproject.org/fedmsg/{crl,ca}.pem``.
- We try to write them to ``/var/cache/fedmsg/foo`` first.  If we don't have
  rights to write there, we try to write them instead to ``~/.local/var/cache/fedmsg/foo``.
- When the *next* message comes in, we try to check if
  ``/var/cache/fedmsg/foo`` is too old.. *but it doesn't exist*.  We wrote it
  to ``~/.local/var/cache/fedmsg/foo`` last time.
- We end up pulling down the CRL and the CA cert *every time* for *every
  message* if we don't have write access to ``/var/cache/fedmsg/``.

This fixes that so that if we find the certs in
``~/.local/var/cache/fedmsg/foo``.. we'll just re-use those (this is the way it
was supposed to work all along).