### PR TITLE
use setsockopt_string when setting a string as the option

### DIFF
--- a/fedmsg/core.py
+++ b/fedmsg/core.py
@@ -365,7 +365,7 @@ class FedMsgContext(object):
 
                 # OK, sanity checks pass.  Create the subscriber and connect.
                 subscriber = self.context.socket(zmq.SUB)
-                subscriber.setsockopt(zmq.SUBSCRIBE, topic)
+                subscriber.setsockopt_string(zmq.SUBSCRIBE, topic)
 
                 set_high_water_mark(subscriber, self.c)
                 set_tcp_keepalive(subscriber, self.c)


### PR DESCRIPTION
setsockopt() accepts, strictly, an int or a bytestring as the
option value. Here we want to use a string as the value, so we
should use setsockopt_string(). I checked all other uses and
they look to be using ints as the option values, so they're OK.

Without this fix, reading the first message from tail_messages
will blow up in Python 3.

See https://pyzmq.readthedocs.org/en/latest/api/zmq.html#zmq.Socket.setsockopt_string .