### PR TITLE
ensure we pass a str not a bytes to loads()

### DIFF
--- a/fedmsg/core.py
+++ b/fedmsg/core.py
@@ -405,7 +405,7 @@ class FedMsgContext(object):
         validate = self.c.get('validate_signatures', False)
 
         _topic, message = sock.recv_multipart()
-        msg = fedmsg.encoding.loads(message)
+        msg = fedmsg.encoding.loads(message.decode('utf-8'))
         if not validate or fedmsg.crypto.validate(msg, **self.c):
             # If there is even a slight change of replay, use
             # check_for_replay


### PR DESCRIPTION
another Python 3 fix, again, without this, tail_messages()
blows up pretty fast. In Python 3, message here is a bytes,
it's not a str. loads specifically needs a str.

Note: there are several other suspicious-looking `loads()` calls throughout fedmsg, but it's very very late and I do not feel like investigating them all...