### PR TITLE
instead of setsockopt_string, encode topic and use setsockopt

### DIFF
--- a/fedmsg/core.py
+++ b/fedmsg/core.py
@@ -365,7 +365,7 @@ class FedMsgContext(object):
 
                 # OK, sanity checks pass.  Create the subscriber and connect.
                 subscriber = self.context.socket(zmq.SUB)
-                subscriber.setsockopt_string(zmq.SUBSCRIBE, topic)
+                subscriber.setsockopt(zmq.SUBSCRIBE, topic.encode('utf-8'))
 
                 set_high_water_mark(subscriber, self.c)
                 set_tcp_keepalive(subscriber, self.c)


### PR DESCRIPTION
acc7260 was bad - it blows up in Python 2 because there the
value is not a unicode, and setsockopt_string only accepts
unicodes. Making the value a unicode on Python 2 without
crashing in Python 3 attempting to decode a str is annoying,
so instead let's encode the topic and use setsockopt.

This will blow up in Python 3 if the topic is already encoded,
but I don't think that should happen.