### PR TITLE
Add long_form metadata to the constituents of a grouped event.

### DIFF
--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -312,6 +312,7 @@ class BaseConglomerator(object):
                 'usernames': fm.msg2usernames(msg, **config),
                 'packages': fm.msg2packages(msg, **config),
                 'objects': fm.msg2objects(msg, **config),
+                'long_form': fm.msg2long_form(msg, **config),
             }) for msg in constituents])
 
         return {


### PR DESCRIPTION
Mostly just because I want to use it in fedora-hubs.

We'll use this to embed summaries about blog posts and mailing list threads in your feed!