### PR TITLE
Add the possibility to associate a pygments lexer with a message.

### DIFF
--- a/fedmsg/meta/__init__.py
+++ b/fedmsg/meta/__init__.py
@@ -166,7 +166,7 @@ def with_processor():
     return _wrapper
 
 
-def conglomerate(messages, subject=None, **config):
+def conglomerate(messages, subject=None, lexers=False, **config):
     """ Return a list of messages with some of them grouped into conglomerate
     messages.  Conglomerate messages represent several other messages.
 
@@ -194,7 +194,7 @@ def conglomerate(messages, subject=None, **config):
 
         # For ungrouped ones, replace them with a fake conglomerate
         messages[i] = BaseConglomerator.produce_template(
-            [message], subject=subject, **config)
+            [message], subject=subject, lexers=lexers, **config)
         # And fill out the fields that fully-implemented conglomerators would
         # normally fill out.
         messages[i].update({
@@ -248,6 +248,13 @@ def msg2long_form(msg, processor, **config):
     if not result:
         result = processor.subtitle(msg, **config)
     return result
+
+
+@with_processor()
+def msg2lexer(msg, processor, **config):
+    """ Return a Pygments lexer able to parse the long_form of this message.
+    """
+    return processor.lexer(msg, **config)
 
 
 @legacy_condition(six.text_type)

--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -168,6 +168,13 @@ class BaseProcessor(object):
         """ Return some paragraphs of text about a message. """
         return ""
 
+    def lexer(self, msg, **config):
+        """ Return a pygments lexer that can be applied to the long_form.
+
+        Returns None if no lexer is associated.
+        """
+        return None
+
     def link(self, msg, **config):
         """ Return a "link" for the message. """
         return ""
@@ -226,7 +233,7 @@ class BaseConglomerator(object):
         self.processor = processor
         self._ = internationalization_callable
 
-    def conglomerate(self, messages, subject=None, **conf):
+    def conglomerate(self, messages, subject=None, lexers=False, **conf):
         """ Top-level API entry point.  Given a list of messages, transform it
         into a list of conglomerates where possible.
         """
@@ -234,7 +241,8 @@ class BaseConglomerator(object):
         while constituents:
             for idx in reversed(indices):
                 messages.pop(idx)
-            messages.insert(idx, self.merge(constituents, subject, **conf))
+            entry = self.merge(constituents, subject, lexers=lexers, **conf)
+            messages.insert(idx, entry)
             indices, constituents = self.select_constituents(messages, **conf)
 
         return messages
@@ -271,7 +279,7 @@ class BaseConglomerator(object):
         return None, None
 
     @classmethod
-    def produce_template(cls, constituents, subject, **config):
+    def produce_template(cls, constituents, subject, lexers=False, **config):
         """ Helper function used by `merge`.
         Produces the beginnings of a merged conglomerate message that needs to
         be later filled out by a subclass.
@@ -308,12 +316,18 @@ class BaseConglomerator(object):
                 'subjective': fm.msg2subjective(msg, subject=subject, **config),
                 'link': fm.msg2link(msg, **config),
                 'icon': fm.msg2icon(msg, **config),
+                '__icon__': getattr(fm.msg2processor(msg, **config), '__icon__', None),
                 'secondary_icon': fm.msg2secondary_icon(msg, **config),
                 'usernames': fm.msg2usernames(msg, **config),
                 'packages': fm.msg2packages(msg, **config),
                 'objects': fm.msg2objects(msg, **config),
                 'long_form': fm.msg2long_form(msg, **config),
             }) for msg in constituents])
+
+        # If the user asks for it, stuff in a pygments lexer too!
+        if lexers:
+            for msg in constituents:
+                msg_ids[msg['msg_id']]['lexer'] = fm.msg2lexer(msg, **config)
 
         return {
             'start_time': min(timestamps),


### PR DESCRIPTION
This is for fedora-hubs.

We add an implementation in fedora-infra/fedmsg_meta_fedora_infrastructure#367
which returns a DiffLexer or a MarkdownLexer for certain kinds of messages.
This will let us render the long-form of those messages nicely in your feed.