### PR TITLE
irc: default color configurable

### DIFF
--- a/fedmsg.d/ircbot.py
+++ b/fedmsg.d/ircbot.py
@@ -47,5 +47,9 @@ config = dict(
         "buildsys": "yellow",
         "planet": "light green",
     },
+
+    # color for title if color lookup not defined
+    default_color='light grey',
+
     irc_method='notice',  # Either 'msg' or 'notice'
 )

--- a/fedmsg.d/ircbot.py
+++ b/fedmsg.d/ircbot.py
@@ -49,7 +49,7 @@ config = dict(
     },
 
     # color for title if color lookup not defined
-    default_color='light grey',
+    irc_default_color='light grey',
 
     irc_method='notice',  # Either 'msg' or 'notice'
 )

--- a/fedmsg/consumers/ircbot.py
+++ b/fedmsg/consumers/ircbot.py
@@ -77,7 +77,8 @@ def ircprettify(title, subtitle, link="", config=None):
         link = ""
 
     color_lookup = config.get('irc_color_lookup', {})
-    title_color = color_lookup.get(title.split('.')[0], "light grey")
+    default_color = config.get('irc_default_color', 'light grey')
+    title_color = color_lookup.get(title.split('.')[0], default_color)
     title = markup(title, title_color)
 
     fmt = u"{title} -- {subtitle} {link}"


### PR DESCRIPTION
i use light terminal, so text in 'light grey' color is unreadable