### PR TITLE
Cascade IRC connections.

### DIFF
--- a/fedmsg/consumers/ircbot.py
+++ b/fedmsg/consumers/ircbot.py
@@ -168,6 +168,8 @@ class Fedmsg2IRCFactory(protocol.ClientFactory):
             # one should trigger joining the third one...
             self.log.info("%s scheduling conn for next client" % self.nickname)
             reactor.callLater(1, self.ready)
+            # Un set this so we don't trigger it again later on a reconnect...
+            self.ready = None
 
     def clientConnectionLost(self, connector, reason):
         if self.parent_consumer.die:

--- a/fedmsg/consumers/ircbot.py
+++ b/fedmsg/consumers/ircbot.py
@@ -166,6 +166,7 @@ class Fedmsg2IRCFactory(protocol.ClientFactory):
             # If we're joining 12 channels, join one of them first.  Once
             # joining, wait one second and start joining the second one.  That
             # one should trigger joining the third one...
+            self.log.info("%s scheduling conn for next client" % self.nickname)
             reactor.callLater(1, self.ready)
 
     def clientConnectionLost(self, connector, reason):

--- a/fedmsg/consumers/ircbot.py
+++ b/fedmsg/consumers/ircbot.py
@@ -164,10 +164,10 @@ class Fedmsg2IRCFactory(protocol.ClientFactory):
     def startedConnecting(self, connector):
         if self.ready:
             # If we're joining 12 channels, join one of them first.  Once
-            # joining, wait one second and start joining the second one.  That
-            # one should trigger joining the third one...
+            # joining, wait five seconds and start joining the second one.
+            # That one should trigger joining the third one...
             self.log.info("%s scheduling conn for next client" % self.nickname)
-            reactor.callLater(1, self.ready)
+            reactor.callLater(5, self.ready)
             # Un set this so we don't trigger it again later on a reconnect...
             self.ready = None
 


### PR DESCRIPTION
This makes it so that, if we are joining 12 channels as 12 bots, we won't try
to do them all at the same time.  We'll connect to one, and then once that is
started we'll wait 1 second and then start the second connection.  The start of
that one will wait 1 second and trigger the third, etc...