### PR TITLE
Fix and unite local and hosted testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
- - "2.6"
  - "2.7"
  - "3.3"
  - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
 
 install:
  - pip install -e .[commands,consumers]
- - pip install nose mock sqlalchemy unittest2
-script: nosetests -v
+ - pip install nose
+script: python setup.py nosetests
 notifications:
     email: false
     irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
  - "2.7"
  - "3.3"
  - "3.4"
+ - "3.5"
 
 install:
  - pip install -e .[commands,consumers]
@@ -19,3 +20,4 @@ matrix:
   allow_failures:
     - python: "3.3"
     - python: "3.4"
+    - python: "3.5"

--- a/fedmsg/commands/__init__.py
+++ b/fedmsg/commands/__init__.py
@@ -24,12 +24,7 @@ import six
 import sys
 
 import logging
-try:
-    # Python2.7 and later
-    from logging.config import dictConfig
-except ImportError:
-    # For Python2.6, we rely on a third party module.
-    from logutils.dictconfig import dictConfig
+from logging.config import dictConfig
 
 
 class BaseCommand(object):

--- a/fedmsg/consumers/__init__.py
+++ b/fedmsg/consumers/__init__.py
@@ -114,10 +114,8 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
         self.status_filename, self.status_lock = None, None
         if self.status_directory:
 
-            # Extract proc name and handle differences between py2.6 and py2.7
-            proc_name = current_proc().name
-            if callable(proc_name):
-                proc_name = proc_name()
+            # Extract proc name
+            proc_name = current_proc().name()
 
             self.status_filename = os.path.join(
                 self.status_directory, proc_name, type(self).__name__)

--- a/fedmsg/tests/test_crypto_switching.py
+++ b/fedmsg/tests/test_crypto_switching.py
@@ -23,13 +23,7 @@ import os
 
 import nose.tools.nontrivial
 
-major, minor = sys.version_info[:2]
-if major == 2 and minor <= 6:
-    # For python-2.6, so we can do skipTest
-    import unittest2 as unittest
-else:
-    import unittest
-
+import unittest
 import fedmsg.crypto
 
 SEP = os.path.sep

--- a/fedmsg/tests/test_crypto_x509.py
+++ b/fedmsg/tests/test_crypto_x509.py
@@ -23,13 +23,7 @@ import six
 import sys
 
 import nose.tools.nontrivial
-
-major, minor = sys.version_info[:2]
-if major == 2 and minor <= 6:
-    # For python-2.6, so we can do skipTest
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 import fedmsg.crypto
 

--- a/fedmsg/tests/test_hub.py
+++ b/fedmsg/tests/test_hub.py
@@ -13,12 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    # For python-2.6, so we can do skipTest
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
+import unittest
 import os
 import socket
 

--- a/fedmsg/tests/test_threads.py
+++ b/fedmsg/tests/test_threads.py
@@ -13,12 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    # For python-2.6, so we can do skipTest
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
+import unittest
 import threading
 import copy
 import os

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [nosetests]
 
 where=fedmsg/tests
+verbosity=2
+detailed-errors=1

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,9 @@ extras_require['all'] = list(set(
 ))
 tests_require = [
     'nose',
+    'moksha.hub',
+    'pygments',
+    'psutil',
     'sqlalchemy',  # For the persistent-store test(s).
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -104,15 +104,7 @@ tests_require = [
 
 if sys.version_info[0] == 2:
     tests_require.append('mock')
-    if sys.version_info[1] <= 6:
-        install_requires.extend([
-            'argparse',
-            'ordereddict',
-            'logutils',
-        ])
-        tests_require.extend([
-            'unittest2',
-        ])
+
 
 setup(
     name='fedmsg',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ downloadcache = {toxworkdir}/_download/
 [testenv]
 recreate = True
 basepython =
-    py26: python2.6
     py27: python2.7
     py34: python3.4
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ recreate = True
 basepython =
     py27: python2.7
     py34: python3.4
+    py35: python3.5
 deps =
     six13: six==1.3.0
     six17: six==1.7.3

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py{27}-six{13,17,19}
 downloadcache = {toxworkdir}/_download/
 
 [testenv]
+recreate = True
 basepython =
     py26: python2.6
     py27: python2.7
@@ -12,8 +13,6 @@ deps =
     six17: six==1.7.3
     six19: six>=1.9.0
     nose
-    mock
-    sqlalchemy
 sitepackages = False
 commands =
-    nosetests {posargs}
+    python setup.py nosetests


### PR DESCRIPTION
I noticed attempting to run ``tox -vv`` and ``python setup.py nosetests`` both failed locally unless a number of packages were manually installed first. I also saw there were a few missing packages in the list of requirements. This change adds those testing requirements in and uses the same list for ``tox``, ``nosetests``, and ``travis``.