### PR TITLE
Get fedmsg-hub working on STOMP.

### DIFF
--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -33,7 +33,10 @@ In order to get a fedmsg-hub instance working with STOMP, you should add the
 following configuration to `/etc/fedmsg.d/base.py`::
 
     # We almost always want the fedmsg-hub to be sending messages with zmq as
-    # opposed to amqp or stomp.
+    # opposed to amqp or stomp.  You can send with only *one* of the messaging
+    # backends: zeromq or amqp or stomp.  You cannot send with two or more at
+    # the same time.  Here, zmq is either enabled, or it is not.  If it is not,
+    # see the options below for how to configure stomp or amqp.
     #zmq_enabled=True,
 
     # On the other hand, if you wanted to use STOMP *instead* of zeromq, you

--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -1,0 +1,52 @@
+Compatibility with Other Messaging Technologies
+===============================================
+
+fedmsg was originally built to specifically support zeromq as its messaging backend.
+
+However, we also originally built it on top of `moksha <http://moksha.ws>`_
+which is a framework that already supports not only zeromq, but also STOMP and
+AMQP. In 2016, we added the ability for fedmsg to send and receive messages
+over those protocols (and any others that moksha ends up supporting).
+
+This lets you take advantage of the litany of apps written around the fedmsg
+ecosystem (FMN, fedmsg-irc, datanommer, fedimg, etc..) and run them in other
+messaging environments (STOMP, AMQP, ...).
+
+We intentionally support:
+
+- *The hub/consumer approach*. If you have a fedmsg consumer, it should be able
+  to listen to messages over other protocols now.
+- *Publishing with fedmsg.publish*. This will only work from a fedmsg consumer.
+  It will figure out the moksha context and ask it to publish on fedmsg's
+  behalf, thereby publishing over STOMP or AMQP, depending on configuration.
+
+We intentionally do not support:
+
+- *The naive listening approach*, i.e. `fedmsg.tail_messages()`. It would be
+  much more work and its not worth it in our opinion. If we find a really good
+  reason to implement support for it, we can always revisit this later.
+
+Configuration
+-------------
+
+In order to get a fedmsg-hub instance working with STOMP, you should add the
+following configuration to `/etc/fedmsg.d/base.py`::
+
+    # We almost always want the fedmsg-hub to be sending messages with zmq as
+    # opposed to amqp or stomp.
+    #zmq_enabled=True,
+
+    # On the other hand, if you wanted to use STOMP *instead* of zeromq, you
+    # could do the following...
+    zmq_enabled=False,
+    stomp_uri='broker01.example.com:61612,broker02.example.com:61612',
+    stomp_heartbeat=1000,
+    stomp_user='username',
+    stomp_pass='password',
+    stomp_ssl_crt='/path/to/ssl.crt',
+    stomp_ssl_key='/path/to/ssl.key',
+
+    # This is optional.
+    # If present, the hub will listen only to this queue for all fedmsg consumers.
+    # If absent, the hub will listen to all topics declared by all fedmsg consumers.
+    #stomp_queue='/queue/Consumer.yourqueue',

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -101,6 +101,7 @@ Table of Contents
    crypto
    replay
    meta
+   compatibility
    config
    topics
 

--- a/fedmsg.d/base.py
+++ b/fedmsg.d/base.py
@@ -41,6 +41,15 @@ config = dict(
     # opposed to amqp or stomp.
     zmq_enabled=True,
 
+    # On the other hand, if you wanted to use STOMP *instead* of zeromq, you
+    # could do the following...
+    #zmq_enabled=False,
+    #stomp_uri='localhost:59597,localhost:59598',
+    #stomp_user='username',
+    #stomp_pass='password',
+    #stomp_ssl_crt='/path/to/an/optional.crt',
+    #stomp_ssl_key='/path/to/an/optional.key',
+
     # When subscribing to messages, we want to allow splats ('*') so we tell
     # the hub to not be strict when comparing messages topics to subscription
     # topics.

--- a/fedmsg.d/base.py
+++ b/fedmsg.d/base.py
@@ -38,7 +38,10 @@ config = dict(
     #datagrepper_url="https://apps.fedoraproject.org/datagrepper/raw",
 
     # We almost always want the fedmsg-hub to be sending messages with zmq as
-    # opposed to amqp or stomp.
+    # opposed to amqp or stomp.  You can send with only *one* of the messaging
+    # backends: zeromq or amqp or stomp.  You cannot send with two or more at
+    # the same time.  Here, zmq is either enabled, or it is not.  If it is not,
+    # see the options below for how to configure stomp or amqp.
     zmq_enabled=True,
 
     # On the other hand, if you wanted to use STOMP *instead* of zeromq, you

--- a/fedmsg.d/base.py
+++ b/fedmsg.d/base.py
@@ -61,7 +61,7 @@ config = dict(
     zmq_tcp_keepalive_idle=60,
     zmq_tcp_keepalive_intvl=5,
 
-    # Number of miliseconds that zeromq will wait to reconnect until it gets 
+    # Number of miliseconds that zeromq will wait to reconnect until it gets
     # a connection if an endpoint is unavailable.
     zmq_reconnect_ivl=100,
     # Max delay that you can reconfigure to reduce reconnect storm spam. This

--- a/fedmsg/consumers/__init__.py
+++ b/fedmsg/consumers/__init__.py
@@ -223,6 +223,14 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
             raise RuntimeWarning("Failed to authn message.")
 
     def _consume(self, message):
+
+        # Massage STOMP messages into a more compatible format.
+        if 'topic' not in message['body']:
+            message['body'] = {
+                'topic': message.get('topic'),
+                'msg': message['body'],
+            }
+
         try:
             self.validate(message)
         except RuntimeWarning as e:

--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -154,7 +154,9 @@ class BaseProcessor(object):
             return match.groups()[-1] or ""
 
     def title(self, msg, **config):
-        return '.'.join(msg['topic'].split('.')[3:])
+        if msg['topic'][0].isalpha():
+            return '.'.join(msg['topic'].split('.')[3:])
+        return msg['topic']
 
     def subtitle(self, msg, **config):
         """ Return a "subtitle" for the message. """

--- a/fedmsg/meta/base.py
+++ b/fedmsg/meta/base.py
@@ -154,7 +154,7 @@ class BaseProcessor(object):
             return match.groups()[-1] or ""
 
     def title(self, msg, **config):
-        if msg['topic'][0].isalpha():
+        if not msg['topic'].startswith('/topic/'):
             return '.'.join(msg['topic'].split('.')[3:])
         return msg['topic']
 


### PR DESCRIPTION
The goal here is to be able to take the litany of apps we've written (FMN, fedmsg-irc, datanommer, fedimg, etc..) and be able to run them in other messaging environments (in particular, the RH unified message bus).

I intend to support:

- The hub/consumer approach.  If you have a fedmsg consumer, it should be able
  to listen to messages over other protocols now.
- Publishing with `fedmsg.publish`.  This will only work *from* a fedmsg
  consumer.  It will figure out the moksha context and ask *it* to publish on
  fedmsg's behalf, thereby publishing over STOMP or AMQP, depending on
  configuration.

I explicitly am *not* supporting:

- The naive listening approach, i.e. `fedmsg.tail_messages()`.  It would be a
  ton of work and its not worth it atm.  If we find a *really* good reason to
  implement support for it, we can always revisit this later.