### PR TITLE
Return earlier when validate_signatures is turned off

### DIFF
--- a/fedmsg/consumers/__init__.py
+++ b/fedmsg/consumers/__init__.py
@@ -204,6 +204,10 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
 
     def validate(self, message):
         """ This needs to raise an exception, caught by moksha. """
+        # If we're not validating, then everything is valid.
+        # If this is turned on globally, our child class can override it.
+        if not self.validate_signatures:
+            return
 
         if hasattr(message, '__json__'):
             message = message.__json__()
@@ -213,11 +217,6 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
         # We assume these match inside fedmsg.crypto, so we should enforce it.
         if not message['topic'] == message['body']['topic']:
             raise RuntimeWarning("Topic envelope mismatch.")
-
-        # If we're not validating, then everything is valid.
-        # If this is turned on globally, our child class can override it.
-        if not self.validate_signatures:
-            return
 
         if not fedmsg.crypto.validate(message['body'], **self.hub.config):
             raise RuntimeWarning("Failed to authn message.")


### PR DESCRIPTION
When connecting to a bus without messages being signed, an exception would be raised with the message "Topic envelope mismatch". If signing is turned off, none of the message contents should be examined in the `validate` function.