### PR TITLE
Drop old testcases against old python-six.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27}-six{13,17,19}
+envlist = py{27}-six{19,Latest}
 downloadcache = {toxworkdir}/_download/
 
 [testenv]
@@ -10,9 +10,8 @@ basepython =
     py34: python3.4
     py35: python3.5
 deps =
-    six13: six==1.3.0
-    six17: six==1.7.3
-    six19: six>=1.9.0
+    six19: six==1.9.0
+    sixLatest: six>1.9.0
     nose
 sitepackages = False
 commands =


### PR DESCRIPTION
It used to be 1.7 on RHEL7, but they upgraded and we only have to worry about 1.9 now.