### PR TITLE
Library branding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-fedmsg -- Fedora Messaging Client API
+fedmsg -- Federated Message Bus Client API
 =====================================
 
 .. split here

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 fedmsg -- Federated Message Bus Client API
-=====================================
+==========================================
 
 .. split here
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,8 @@ fedmsg -- Federated Message Bus Client API
 
 .. split here
 
-Utilities used around Fedora Infrastructure to send and receive messages.
+fedmsg (FEDerated MeSsaGe bus) is a python package and API defining a brokerless messaging architecture to send and receive messages to and from applications.
+
 Please see doc `here <https://github.com/fedora-infra/fedmsg/tree/develop/doc>`_ or `fedmsg online doc <https://fedmsg.readthedocs.org/>`_ for more info.
 
 Build Status

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -95,7 +95,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Fedora Messaging'
+project = u'Federated Message Bus'
 copyright = u'2012 - 2014 Red Hat, Inc. and others.'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,7 +20,7 @@ after it was also adopted for
 ``#fedora-fedmsg`` channel on the freenode network with a firehose bot echoing
 messages to channel to help give you a feel for what's going on.
 
-You can find the list of available topics in Fedora' s infrastructure
+You can find the list of available topics in Fedora's infrastructure
 at https://fedora-fedmsg.readthedocs.io
 
 Receiving Messages with Python

--- a/extras/mediawiki/fedmsg-emit.php
+++ b/extras/mediawiki/fedmsg-emit.php
@@ -3,8 +3,7 @@
  * fedmsg-emit.php
  * -------------------------
  *
- * A MediaWiki plugin that emits messages to the Fedora Infrastructure Message
- * Bus.
+ * A MediaWiki plugin that emits messages to the Federated Message Bus.
  *
  * Installation Instructions
  * -------------------------

--- a/fedmsg/__init__.py
+++ b/fedmsg/__init__.py
@@ -17,7 +17,7 @@
 #
 # Authors:  Ralph Bean <rbean@redhat.com>
 #
-""" Fedora Messaging Client API """
+""" Federated Message Bus Client API """
 
 import inspect
 import threading

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ if sys.version_info[0] == 2:
 setup(
     name='fedmsg',
     version='0.18.1',
-    description="Fedora Messaging Client API",
+    description="Federated Message Bus Client API",
     long_description=long_description,
     author='Ralph Bean',
     author_email='rbean@redhat.com',


### PR DESCRIPTION
Thiis changes the references for Fedora Messaging to Federated Message Bus.

Related to discussions in #373, #383.