### PR TITLE
Fedmsg-relay shouldn't run producers.

### DIFF
--- a/fedmsg/commands/relay.py
+++ b/fedmsg/commands/relay.py
@@ -68,6 +68,8 @@ class RelayCommand(BaseCommand):
                     options=self.config,
                     # Only run this *one* consumer
                     consumers=[RelayConsumer],
+                    # And no producers.
+                    producers=[],
                     # Tell moksha to quiet its logging.
                     framework=False,
                 )


### PR DESCRIPTION
If another package happens to be installed in the system, running
`fedmsg-relay` shouldn't inadvertently start that thing.