### PR TITLE
New hmac backend to sign and validate messages

### DIFF
--- a/fedmsg/core.py
+++ b/fedmsg/core.py
@@ -288,7 +288,10 @@ class FedMsgContext(object):
 
         # Find my message-signing cert if I need one.
         if self.c.get('sign_messages', False):
-            if not self.c.get("crypto_backend") == "gpg":
+            if self.c.get("crypto_backend") == "gpg":
+                if 'gpg_signing_key' not in self.c:
+                    self.c['gpg_signing_key'] = self.c['gpg_keys'][self.hostname]
+            else:
                 if 'cert_prefix' in self.c:
                     cert_index = "%s.%s" % (self.c['cert_prefix'],
                                             self.hostname)
@@ -298,9 +301,6 @@ class FedMsgContext(object):
                         cert_index = "shell.%s" % self.hostname
 
                 self.c['certname'] = self.c['certnames'][cert_index]
-            else:
-                if 'gpg_signing_key' not in self.c:
-                    self.c['gpg_signing_key'] = self.c['gpg_keys'][self.hostname]
 
         if self.c.get('sign_messages', False):
             msg = fedmsg.crypto.sign(msg, **self.c)

--- a/fedmsg/core.py
+++ b/fedmsg/core.py
@@ -291,6 +291,9 @@ class FedMsgContext(object):
             if self.c.get("crypto_backend") == "gpg":
                 if 'gpg_signing_key' not in self.c:
                     self.c['gpg_signing_key'] = self.c['gpg_keys'][self.hostname]
+            elif self.c.get("crypto_backend") == "hmac":
+                # There isn't really anything to configure
+                pass
             else:
                 if 'cert_prefix' in self.c:
                     cert_index = "%s.%s" % (self.c['cert_prefix'],

--- a/fedmsg/crypto/__init__.py
+++ b/fedmsg/crypto/__init__.py
@@ -168,10 +168,12 @@ else:
     from . import x509
 
 from . import gpg
+from . import fedhmac
 
 _possible_backends = {
     'gpg': gpg,
     'x509': x509,
+    'hmac': fedhmac,
 }
 
 
@@ -182,12 +184,15 @@ def init(**config):
 
         - 'x509' - Uses x509 certificates.
         - 'gpg' - Uses GnuPG keys.
+        - 'hmac' - Uses hmac.
     """
     global _implementation
     global _validate_implementations
 
     if config.get('crypto_backend') == 'gpg':
         _implementation = gpg
+    elif config.get('crypto_backend') == 'hmac':
+        _implementation = fedhmac
     else:
         _implementation = x509
 
@@ -197,6 +202,8 @@ def init(**config):
             _validate_implementations.append(gpg)
         elif mod == 'x509':
             _validate_implementations.append(x509)
+        elif mod == 'hmac':
+            _validate_implementations.append(fedhmac)
         else:
             raise ValueError("%r is not a valid crypto backend" % mod)
 
@@ -248,6 +255,8 @@ def validate(message, **config):
         backend = x509
     elif 'signature' in message:
         backend = gpg
+    elif 'hmac' in message:
+        backend = fedhmac
     else:
         log.warn('Could not determine crypto backend.  Message unsigned?')
         return False

--- a/fedmsg/crypto/fedhmac.py
+++ b/fedmsg/crypto/fedhmac.py
@@ -1,0 +1,91 @@
+# This file is part of fedmsg.
+# Copyright (C) 2017 Pierre-Yves Chibon <pingou@pingoured.fr>
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Pierre-Yves Chibon <pingou@pingoured.fr>
+#           Ralph Bean <rbean@redhat.com>
+
+import os
+import hashlib
+import hmac
+
+import six
+
+
+import logging
+log = logging.getLogger(__name__)
+
+
+class GpgBinaryError(Exception):
+    pass
+
+
+# Here comes the part actually relevent to fedmsg
+""" ``fedmsg.crypto.hmac`` - Simple hmac backend for :mod:`fedmsg.crypto` """
+import fedmsg.encoding
+
+
+def sign(message, hmac_token, hash_method=None, **config):
+    """ Insert a new field into the message dict and return it.
+
+    The new field is:
+
+        - 'hmac - the computed hmac digest of the JSON repr
+          of the `msg` field.
+    """
+
+    message['crypto'] = 'hmac'
+
+    if hash_method is None:
+        hash_method = 'sha526'
+
+    if not hasattr(hashlib, hash_method):
+        raise HmacError('Invalid hash method: %s' % hash_method)
+
+    signature = hmac.new(
+        hmac_token,
+        fedmsg.encoding.dumps(message['msg']),
+        getattr(hashlib, hash_method),
+    )
+    return dict(list(message.items()) + [('hmac', signature.hexdigest())])
+
+
+def validate(message, hmac_token, hash_method=None, **config):
+    """ Return true or false if the message is signed appropriately.
+
+    Two things must be true:
+
+        1) The signature must be valid (obviously)
+        2) The hmac token on the receiving end must be 
+           the same as on the sending end.
+    """
+    if hash_method is None:
+        hash_method = 'sha526'
+
+    if not hasattr(hashlib, hash_method):
+        raise HmacError('Invalid hash method: %s' % hash_method)
+
+    signature = hmac.new(
+        hmac_token,
+        fedmsg.encoding.dumps(message['msg']),
+        getattr(hashlib, hash_method),
+    ).hexdigest()
+
+    if signature == message['hmac']:
+        return True
+    else:
+        log.warn("Failed validation. {0} != {1}".format(signature, message['hmac']))
+        return False


### PR DESCRIPTION
This backend should make it easier for people to use fedmsg for smaller
deployment than the one used by Debian or the Fedora infrastructure and
where it is easier to keep the secret used... secret.
It should also make it easier to run fedmsg for development while still
having signed messages.
