### PR TITLE
Allow fedmsg-tail to be daemonizable

### DIFF
--- a/fedmsg/commands/tail.py
+++ b/fedmsg/commands/tail.py
@@ -38,6 +38,7 @@ class TailCommand(BaseCommand):
     """ Watch all endpoints on the bus and print each message to stdout. """
 
     name = "fedmsg-tail"
+    daemonizable = True
     extra_args = [
         (['--topic'], {
             'dest': 'topic',


### PR DESCRIPTION
Fedmsg-tail is a great tool for testing, however it currently required
2 terminals (or screen) to be used properly.  Fedmsg already support
other commands to be run as daemons, so lets add that support to
fedmsg-tail.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>