### PR TITLE
Remove artifical keys from datagrepper backlog to pass validation.

### DIFF
--- a/fedmsg/consumers/__init__.py
+++ b/fedmsg/consumers/__init__.py
@@ -169,6 +169,17 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
 
         retrieved = 0
         for message in self.get_datagrepper_results(then, now):
+
+            # Take the messages from datagrepper and remove any keys that were
+            # artificially added to the message.  The presence of these would
+            # otherwise cause message crypto validation to fail.
+            for artificial_key in ('source_name', 'source_version'):
+                if artificial_key in message:
+                    del message[artificial_key]
+
+            # Also, we expect the timestamp to be an 'int'
+            message['timestamp'] = int(message['timestamp'])
+
             if message['msg_id'] != last['msg_id']:
                 retrieved = retrieved + 1
                 self.incoming.put(dict(body=message, topic=message['topic']))


### PR DESCRIPTION
Today, when fedmsg-hub starts up, it tries to read in its backlog of
messages from datagrepper in case it missed anything.  It successfully
gets the list, but then every single one of the messages fails
validation.

There's a gist here that demonstrates what needs to happen to make this
work:  https://gist.github.com/ralphbean/b532ad3bc4a8333fa03d4e4e48451885

There are two changes required.  This one here, in fedmsg, and another in
fedora-infra/datanommer#87.