### PR TITLE
Set Travis CI to run via tox

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+include =
+    fedmsg/*
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:
+omit =
+    fedmsg/tests/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ html-output
 htmldoc
 _tweet-real.py
 htmldocs
+htmlcov/
 .coverage
 fedmsg/tests/test_certs/gpg/random_seed
 html-docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
+sudo: true
 language: python
-python:
- - "2.6"
- - "2.7"
- - "3.3"
- - "3.4"
- - "3.5"
 
 # Twisted dropped Python 2.6 support, so install a compatible version on 2.6
 install:
+ - sudo apt-get install swig
  - pip install --upgrade pip setuptools
- - pip install -r test-requirements.txt
- - pip install -e .[commands,consumers]
-script: python setup.py nosetests
+ - pip install tox
+
+script:
+  - tox
+
+after_success:
+  - source .tox/${TOXENV}/bin/activate && pip install codecov && codecov
+
 notifications:
     email: false
     irc:
@@ -19,8 +20,22 @@ notifications:
     on_success: change
     on_failure: change
 
+env:
+  global:
+    - PYTHONWARNINGS=always::DeprecationWarning
 matrix:
+  include:
+    - python: "2.6"
+      env: TOXENV=py26
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
   allow_failures:
-    - python: "3.3"
     - python: "3.4"
     - python: "3.5"
+    - python: "3.6"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 nose
+pytest-cov
 moksha.hub
 pygments
 psutil

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,8 @@ whitelist_externals =
     rm
 commands =
     rm -rf htmlcov coverage.xml
-    python setup.py nosetests
+    pytest -vv --cov-config .coveragerc --cov=fedmsg --cov-report term \
+        --cov-report xml --cov-report html
 
 [testenv:docs]
 changedir = doc

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,42 @@
 [tox]
-envlist = py{27}-six{19,Latest}
-downloadcache = {toxworkdir}/_download/
+envlist = lint,py26,py27,py34,py35,py36,docs
 
 [testenv]
+passenv = TRAVIS TRAVIS_*
+extras =
+    crypto
+    commands
+    consumers
 recreate = True
-basepython =
-    py26: python2.6
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
 deps =
-    six19: six==1.9.0
-    sixLatest: six>1.9.0
-    nose
+    -rtest-requirements.txt
 sitepackages = False
+whitelist_externals =
+    rm
 commands =
+    rm -rf htmlcov coverage.xml
     python setup.py nosetests
+
+[testenv:docs]
+changedir = doc
+deps =
+    sphinx
+    cloud_sptheme
+whitelist_externals =
+    mkdir
+    rm
+commands=
+    mkdir -p _static
+    rm -rf _build
+    sphinx-build -W -b html -d {envtmpdir}/doctrees .  _build/html
+
+[testenv:lint]
+deps =
+    flake8 > 3.0
+commands =
+    python -m flake8 {posargs}
+
+[flake8]
+show-source = True
+max-line-length = 100
+exclude = .git,.tox,dist,*egg


### PR DESCRIPTION
This unifies the tox test environment with the CI environment so that users can run the same test environment CI does.

Additionally, it switches the test runner to pytest (since nose is dead) and generates a coverage report.