### PR TITLE
Use irc logger instead of moksha.hub.

### DIFF
--- a/fedmsg/consumers/ircbot.py
+++ b/fedmsg/consumers/ircbot.py
@@ -166,26 +166,26 @@ class Fedmsg2IRCFactory(protocol.ClientFactory):
             # If we're joining 12 channels, join one of them first.  Once
             # joining, wait five seconds and start joining the second one.
             # That one should trigger joining the third one...
-            self.log.info("%s scheduling conn for next client" % self.nickname)
+            log.info("%s scheduling conn for next client" % self.nickname)
             reactor.callLater(5, self.ready)
             # Un set this so we don't trigger it again later on a reconnect...
             self.ready = None
 
     def clientConnectionLost(self, connector, reason):
         if self.parent_consumer.die:
-            self.log.info("Lost connection.  Not reconnecting to IRC.")
+            log.info("Lost connection.  Not reconnecting to IRC.")
             return
 
-        self.log.warning("Lost connection (%s), reconnecting." % (reason,))
+        log.warning("Lost connection (%s), reconnecting." % (reason,))
         self.parent_consumer.del_irc_clients(factory=self)
         connector.connect()
 
     def clientConnectionFailed(self, connector, reason):
         if self.parent_consumer.die:
-            self.log.info("Failed connection.  Not reconnecting to IRC.")
+            log.info("Failed connection.  Not reconnecting to IRC.")
             return
 
-        self.log.error("Could not connect: %s, retry in 60s" % (reason,))
+        log.error("Could not connect: %s, retry in 60s" % (reason,))
         self.parent_consumer.del_irc_clients(factory=self)
         reactor.callLater(60, connector.connect)
 
@@ -215,7 +215,7 @@ class IRCBotConsumer(FedmsgConsumer):
             use_ssl = settings.get('ssl', False)
             channel = settings.get('channel', None)
             if not channel:
-                self.log.error("No channel specified.  Ignoring entry.")
+                log.error("No channel specified.  Ignoring entry.")
                 continue
 
             if not channel.startswith("#"):
@@ -253,6 +253,7 @@ class IRCBotConsumer(FedmsgConsumer):
         # Call only the very last one.
         # When it is done, it will call the second to last one, which when it
         # is done will call the third to last one, etc..
+        log.info("Scheduling connection: %r" % callback)
         callback()
 
     def add_irc_client(self, client):
@@ -360,7 +361,7 @@ class IRCBotConsumer(FedmsgConsumer):
                 backlog = self.incoming.qsize()
                 if backlog and (backlog % 20) == 0:
                     warning = "* backlogged by %i messages" % backlog
-                    self.log.warning(warning)
+                    log.warning(warning)
                     send(client.factory.channel, warning.encode('utf-8'))
 
     def stop(self):


### PR DESCRIPTION
This will make debugging much easier.  Currently, if connections fail you see
"[moksha.hub] Could not connect".  After this change you should see
"[fedmsg.consumers.ircbot] Could not connect." which gives much better
information.