### PR TITLE
Make the ircbot url shortener configurable.

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -312,6 +312,7 @@ Glossary of Configuration Values
           ...
           ...             make_pretty=True,
           ...             make_terse=True,
+          ...             make_short=True,
           ...
           ...             filters=dict(
           ...                 topic=['koji'],
@@ -330,6 +331,13 @@ Glossary of Configuration Values
         ``make_terse`` specifies that the "natural language" representations
         produced by :mod:`fedmsg.meta` should be echoed into the channel instead
         of raw or dumb representations.
+
+        ``make_short`` specifies that any url associated with the message
+        should be shortened with a link shortening service.  If `True`, the
+        https://da.gd/ service will be used.  You can alternatively specify a
+        `callable` to use your own custom url shortener, like this::
+
+            make_short=lambda url: requests.get('http://api.bitly.com/v3/shorten?login=YOURLOGIN&apiKey=YOURAPIKEY&longUrl=%s&format=txt' % url).text.strip()
 
         The ``filters`` dict is not very smart.  In the above case, any message
         that has 'koji' anywhere in the topic or 'ralph' anywhere in the JSON

--- a/fedmsg/consumers/ircbot.py
+++ b/fedmsg/consumers/ircbot.py
@@ -66,6 +66,12 @@ mirc_colors = {
 }
 
 
+def _default_link_shortener(url):
+    dagd = 'http://da.gd/s'
+    resp = requests.get(dagd, params=dict(url=url))
+    return resp.text.strip()
+
+
 def ircprettify(title, subtitle, link="", config=None):
     def markup(s, color):
         return "\x03%i%s\x03" % (mirc_colors[color], s)
@@ -307,9 +313,10 @@ class IRCBotConsumer(FedmsgConsumer):
                     link = fedmsg.meta.msg2link(msg, **self.hub.config)
 
                 if link and short:
-                    dagd = 'http://da.gd/s'
-                    resp = requests.get(dagd, params=dict(url=link))
-                    link = resp.text.strip()
+                    if callable(short):
+                        link = short(link)
+                    else:
+                        link = _default_link_shortener(link)
 
                 return ircprettify(
                     title=title,

--- a/fedmsg/consumers/ircbot.py
+++ b/fedmsg/consumers/ircbot.py
@@ -68,8 +68,12 @@ mirc_colors = {
 
 def _default_link_shortener(url):
     dagd = 'http://da.gd/s'
-    resp = requests.get(dagd, params=dict(url=url))
-    return resp.text.strip()
+    try:
+        resp = requests.get(dagd, params=dict(url=url), timeout=3)
+        return resp.text.strip()
+    except:
+        log.exception("Failed to shorten %r" % url)
+        return url
 
 
 def ircprettify(title, subtitle, link="", config=None):


### PR DESCRIPTION
Someone can provide something like this in their configuration to make link
shortening work in... some other way::

```python
config = dict(
    irc=[dict(
            make_short=lambda url: "http://awesome",
    )],
)
```