### PR TITLE
add topic_prefix example

### DIFF
--- a/fedmsg.d/base.py
+++ b/fedmsg.d/base.py
@@ -20,6 +20,9 @@
 import os
 
 config = dict(
+    # Prefix for the topic of each message sent.
+    topic_prefix="org.fedoraproject",
+
     # Set this to dev if you're hacking on fedmsg or an app.
     # Set to stg or prod if running in the Fedora Infrastructure
     environment="dev",


### PR DESCRIPTION
currently it's not visible, [hardcoded value](https://github.com/fedora-infra/fedmsg/blob/0.18.3/fedmsg/config.py#L55) from codebase