### PR TITLE
Pass along headers if present.

### DIFF
--- a/fedmsg/consumers/ircbot.py
+++ b/fedmsg/consumers/ircbot.py
@@ -342,6 +342,11 @@ class IRCBotConsumer(FedmsgConsumer):
         log.debug("Got message %r" % msg)
         topic, body = msg.get('topic'), msg.get('body')
 
+        # Pass along headers if present.  May be useful to filters or
+        # fedmsg.meta routines.
+        if 'headers' in msg:
+            body['headers'] = msg['headers']
+
         for client in self.irc_clients:
             if not client.factory.filters or (
                 client.factory.filters and

--- a/fedmsg/tests/consumers/test_irc.py
+++ b/fedmsg/tests/consumers/test_irc.py
@@ -1,0 +1,51 @@
+import unittest
+
+import mock
+
+from fedmsg.consumers import ircbot
+
+
+class TestIRCConsumer(unittest.TestCase):
+    """Tests for the :class:`fedmsg.consumers.ircbot.IRCBotConsumer`."""
+
+    def setUp(self):
+        self.hub = mock.Mock()
+        self.hub.config = {
+            'fedmsg.consumers.ircbot.enabled': True,
+            'topic_prefix_re': 'whatever...',
+            'irc_method': 'notice',
+            'irc': [
+                dict(
+                    network='irc.freenode.net',
+                    port=6667,
+                    ssl=False,
+                    nickname='fedmsg-dev',
+                    channel='my-fedmsg-channel',
+                    timeout=120,
+                    make_pretty=True,
+                    make_terse=True,
+                    make_short=True,
+                    line_rate=0.9,
+                    filters=dict(),
+                ),
+            ]
+        }
+
+    @mock.patch('fedmsg.consumers.ircbot.IRCBotConsumer.apply_filters')
+    @mock.patch('fedmsg.consumers.ircbot.IRCBotConsumer.prettify')
+    def test_message_headers(self, prettify, apply_filters):
+        """ Assert that headers are copied into the inner message.
+
+        https://github.com/fedora-infra/fedmsg/pull/432
+        """
+        apply_filters.return_value = True
+        consumer = ircbot.IRCBotConsumer(self.hub)
+        consumer.irc_clients = [mock.Mock()]
+        consumer.consume({'topic': 'testtopic', 'body': {'my': 'msg'}, 'headers': 'awesome'})
+        consumer.prettify.assert_called_once_with(
+            topic='testtopic',
+            msg=dict(my='msg', headers='awesome'),
+            pretty=mock.ANY,
+            short=mock.ANY,
+            terse=mock.ANY,
+        )


### PR DESCRIPTION
These may be useful to filters or fedmsg.meta routines.