### PR TITLE
Fix monitoring for fedmsg-relay

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,6 +18,9 @@ coverage:
         enabled: yes
         target: 100%  # Require 100% coverage on all PRs
 
+  ignore:
+    - "fedmsg/tests/*"
+
 parsers:
   gcov:
     branch_detection:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,6 @@
 [run]
 branch = True
-include =
-    fedmsg/*
+source = fedmsg
 
 [report]
 precision = 2

--- a/fedmsg/commands/relay.py
+++ b/fedmsg/commands/relay.py
@@ -22,6 +22,8 @@
 
 import zmq
 
+from moksha.hub.monitoring import MonitoringProducer
+
 from fedmsg.commands import BaseCommand
 from fedmsg.consumers.relay import RelayConsumer, SigningRelayConsumer
 
@@ -69,8 +71,7 @@ class RelayCommand(BaseCommand):
                     options=self.config,
                     # Only run this *one* consumer
                     consumers=[self.relay_consumer],
-                    # And no producers.
-                    producers=[],
+                    producers=[MonitoringProducer],
                     # Tell moksha to quiet its logging.
                     framework=False,
                 )

--- a/fedmsg/commands/relay.py
+++ b/fedmsg/commands/relay.py
@@ -22,6 +22,7 @@
 
 import zmq
 
+from moksha.hub import main
 from moksha.hub.monitoring import MonitoringProducer
 
 from fedmsg.commands import BaseCommand
@@ -62,7 +63,6 @@ class RelayCommand(BaseCommand):
         # Flip the special bit that allows the RelayConsumer to run
         self.config[self.relay_consumer.config_key] = True
 
-        from moksha.hub import main
         for publish_endpoint in self.config['endpoints']['relay_outbound']:
             self.config['zmq_publish_endpoints'] = publish_endpoint
             try:

--- a/fedmsg/tests/commands/test_relay.py
+++ b/fedmsg/tests/commands/test_relay.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of fedmsg.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+"""Tests for the :mod:`fedmsg.commands.relay` module."""
+from __future__ import absolute_import
+
+import unittest
+
+from moksha.hub import monitoring
+import mock
+
+from fedmsg.commands import relay
+
+
+@mock.patch('fedmsg.commands.relay.main')
+class RelayCommandTests(unittest.TestCase):
+    """Tests for the plain ``fedmsg-relay`` command."""
+
+    def setUp(self):
+        with mock.patch.object(relay.RelayCommand, '__init__', mock.Mock(return_value=None)):
+            self.command = relay.RelayCommand()
+        self.command.config = {
+            'relay_inbound': ['circus', 'of', 'values'],
+            'endpoints': {'relay_outbound': ['some-socket']},
+        }
+        self.expected_config = self.command.config.copy()
+        self.expected_config['zmq_subscribe_endpoints'] = 'circus,of,values'
+        self.expected_config['zmq_subscribe_method'] = 'bind'
+        self.expected_config['zmq_publish_endpoints'] = 'some-socket'
+        self.expected_config['fedmsg.consumers.relay.enabled'] = True
+
+    def test_config(self, mock_main):
+        """Assert the configuration is modified as expected."""
+        self.command.run()
+        self.assertEqual(self.expected_config, self.command.config)
+
+    def test_return_value(self, mock_main):
+        """Assert the command returns the result of ``moksha.hub.main``."""
+        result = self.command.run()
+        self.assertTrue(result is mock_main.return_value)
+
+    def test_main(self, mock_main):
+        """Assert the command creates a monitoring producer and a relay consumer."""
+        self.command.run()
+        mock_main.assert_called_once_with(
+            options=self.expected_config,
+            consumers=[relay.RelayConsumer],
+            producers=[monitoring.MonitoringProducer],
+            framework=False,
+        )

--- a/fedmsg/tests/test_commands.py
+++ b/fedmsg/tests/test_commands.py
@@ -17,7 +17,6 @@ import fedmsg.config
 import fedmsg.commands
 from fedmsg.commands.hub import HubCommand
 from fedmsg.commands.logger import LoggerCommand
-from fedmsg.commands.relay import RelayCommand
 from fedmsg.commands.tail import TailCommand
 from fedmsg.commands.config import config as config_command
 from fedmsg.commands.check import check
@@ -166,28 +165,6 @@ class TestCommands(unittest.TestCase):
         output = stdout.getvalue()
         expected = '\x1b[33m"hello"\x1b[39;49;00m'
         assert(expected in output)
-
-    @mock.patch("sys.argv", new_callable=lambda: ["fedmsg-relay"])
-    def test_relay(self, argv):
-        actual_options = []
-
-        def mock_main(options, consumers, producers, framework):
-            actual_options.append(options)
-
-        config = {}
-        with mock.patch("fedmsg.__local", self.local):
-            with mock.patch("fedmsg.config.__cache", config):
-                with mock.patch("moksha.hub.main", mock_main):
-                    command = RelayCommand()
-                    command.execute()
-
-        actual_options = actual_options[0]
-        assert(
-            fedmsg.consumers.relay.RelayConsumer.config_key in actual_options
-        )
-        assert(
-            actual_options[fedmsg.consumers.relay.RelayConsumer.config_key]
-        )
 
     @mock.patch("sys.argv", new_callable=lambda: ["fedmsg-config"])
     @mock.patch("sys.stdout", new_callable=six.StringIO)


### PR DESCRIPTION
This fixes an issue introduced in #395 that stopped the fedmsg relay
from starting a monitoring producer. This explicitly defines the
monitoring producer as the only producer so that any additional producer
entry points are not used.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>