### PR TITLE
Mark the --daemon option as deprecated

### DIFF
--- a/fedmsg/commands/__init__.py
+++ b/fedmsg/commands/__init__.py
@@ -81,6 +81,9 @@ class BaseCommand(object):
         except:
             from daemon.pidlockfile import PIDLockFile
 
+        msg = ('The use of the "--daemon" flag is deprecated and will be removed in '
+               'fedmsg-0.20.0. Use your init system to run fedmsg commands as daemons.')
+        warnings.warn(msg, category=UserWarning)
         pidlock = PIDLockFile('/var/run/fedmsg/%s.pid' % self.name)
 
         pid = pidlock.read_pid()

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ extras_require = {
     ],
     'consumers': [
         'moksha.hub>=1.3.0',
-        'daemon',      # not *necessarily* required
+        'python-daemon',      # not *necessarily* required
         'pygments',
         'psutil',
         # only needed for irc ssl support


### PR DESCRIPTION
The setup.py also depended on the wrong PyPI package.

fixes #423

Signed-off-by: Jeremy Cline <jeremy@jcline.org>