### PR TITLE
Add a codecov configuration to enforce coverage increase

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,25 @@
+# Consult https://github.com/codecov/support/wiki/Codecov-Yaml for docs.
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "80...100"  # Make 80% be angry red and 100% be happy green.
+
+  status:
+    project:
+      default:
+        enabled: yes
+        target: auto  # Coverage must increase or remain constant
+    patch:
+      default:
+        enabled: yes
+        target: 100%  # Require 100% coverage on all PRs
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - tox
 
 after_success:
-  - source .tox/${TOXENV}/bin/activate && pip install codecov && codecov
+  - source .tox/${TOXENV}/bin/activate && pip install codecov && codecov --env TRAVIS_OS_NAME,TOXENV
 
 notifications:
     email: false


### PR DESCRIPTION
This should make it so coverage _must_ increase or remain constant, and also enforce that a patch have 100% coverage.