### PR TITLE
Pass along headers for *all* consumers, not just the irc bot.

### DIFF
--- a/fedmsg/consumers/__init__.py
+++ b/fedmsg/consumers/__init__.py
@@ -246,6 +246,12 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
         except RuntimeWarning as e:
             self.log.warn("Received invalid message {0}".format(e))
             return
+
+        # Pass along headers if present.  May be useful to filters or
+        # fedmsg.meta routines.
+        if 'headers' in message and 'body' in message:
+            message['body']['headers'] = message['headers']
+
         if hasattr(self, "replay_name"):
             for m in check_for_replay(
                     self.replay_name, self.name_to_seq_id,

--- a/fedmsg/consumers/ircbot.py
+++ b/fedmsg/consumers/ircbot.py
@@ -342,11 +342,6 @@ class IRCBotConsumer(FedmsgConsumer):
         log.debug("Got message %r" % msg)
         topic, body = msg.get('topic'), msg.get('body')
 
-        # Pass along headers if present.  May be useful to filters or
-        # fedmsg.meta routines.
-        if 'headers' in msg:
-            body['headers'] = msg['headers']
-
         for client in self.irc_clients:
             if not client.factory.filters or (
                 client.factory.filters and

--- a/fedmsg/tests/consumers/test_irc.py
+++ b/fedmsg/tests/consumers/test_irc.py
@@ -12,6 +12,7 @@ class TestIRCConsumer(unittest.TestCase):
         self.hub = mock.Mock()
         self.hub.config = {
             'fedmsg.consumers.ircbot.enabled': True,
+            'moksha.blocking_mode': True,
             'topic_prefix_re': 'whatever...',
             'irc_method': 'notice',
             'irc': [
@@ -41,10 +42,10 @@ class TestIRCConsumer(unittest.TestCase):
         apply_filters.return_value = True
         consumer = ircbot.IRCBotConsumer(self.hub)
         consumer.irc_clients = [mock.Mock()]
-        consumer.consume({'topic': 'testtopic', 'body': {'my': 'msg'}, 'headers': 'awesome'})
+        consumer._consume({'topic': 'testtopic', 'body': {'my': 'msg'}, 'headers': 'awesome'})
         consumer.prettify.assert_called_once_with(
             topic='testtopic',
-            msg=dict(my='msg', headers='awesome'),
+            msg=dict(topic='testtopic', msg=dict(my='msg'), headers='awesome'),
             pretty=mock.ANY,
             short=mock.ANY,
             terse=mock.ANY,


### PR DESCRIPTION
This is on top of #432.  We realized we had the same problem with datanommer that we saw in the irc bot.