### PR TITLE
There won't be a fedmsg-0.20.0

### DIFF
--- a/fedmsg/commands/__init__.py
+++ b/fedmsg/commands/__init__.py
@@ -82,7 +82,7 @@ class BaseCommand(object):
             from daemon.pidlockfile import PIDLockFile
 
         msg = ('The use of the "--daemon" flag is deprecated and will be removed in '
-               'fedmsg-0.20.0. Use your init system to run fedmsg commands as daemons.')
+               'fedmsg-1.0.0. Use your init system to run fedmsg commands as daemons.')
         warnings.warn(msg, category=UserWarning)
         pidlock = PIDLockFile('/var/run/fedmsg/%s.pid' % self.name)
 


### PR DESCRIPTION
There was a deprecation warning referencing 0.20.0, but we determined in
issue #440 that there won't be a 0.20.0 release.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>