### PR TITLE
Add missing test requirement - click

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,3 +11,4 @@ logutils; python_version <= '2.6'
 unittest2; python_version <= '2.6'
 Twisted==12.2; python_version <= '2.6'
 flake8
+click


### PR DESCRIPTION
CliRunner from click.testing is widely used in test_commands.py but it's missing in test-requirements.txt.