### PR TITLE
Allow validating unicode signatures.

### DIFF
--- a/fedmsg/crypto/x509.py
+++ b/fedmsg/crypto/x509.py
@@ -113,7 +113,7 @@ def _m2crypto_validate(message, ssldir=None, **config):
     for field in ['signature', 'certificate']:
         if field not in message:
             return fail("No %r field found." % field)
-        if not isinstance(message[field], str):
+        if not isinstance(message[field], basestring):
             return fail("msg[%r] is not a string" % field)
 
     # Peal off the auth datums

--- a/fedmsg/crypto/x509.py
+++ b/fedmsg/crypto/x509.py
@@ -37,7 +37,7 @@ import fedmsg.crypto  # noqa: E402
 import fedmsg.encoding  # noqa: E402
 
 
-log = logging.getLogger(__name__)
+_log = logging.getLogger(__name__)
 
 if six.PY3:
     long = int
@@ -106,7 +106,7 @@ def _m2crypto_validate(message, ssldir=None, **config):
         raise ValueError("You must set the ssldir keyword argument.")
 
     def fail(reason):
-        log.warn("Failed validation.  %s" % reason)
+        _log.warn("Failed validation.  %s" % reason)
         return False
 
     # Some sanity checking
@@ -114,14 +114,14 @@ def _m2crypto_validate(message, ssldir=None, **config):
         if field not in message:
             return fail("No %r field found." % field)
         if not isinstance(message[field], six.text_type):
-            log.error('msg[%r] is not a unicode string' % field)
+            _log.error('msg[%r] is not a unicode string' % field)
             try:
                 # Make an effort to decode it, it's very likely utf-8 since that's what
                 # is hardcoded throughout fedmsg. Worst case scenario is it'll cause a
                 # validation error when there shouldn't be one.
                 message[field] = message[field].decode('utf-8')
             except UnicodeError as e:
-                log.error("Unable to decode the message '%s' field: %s", field, str(e))
+                _log.error("Unable to decode the message '%s' field: %s", field, str(e))
                 return False
 
     # Peal off the auth datums

--- a/fedmsg/crypto/x509_ng.py
+++ b/fedmsg/crypto/x509_ng.py
@@ -39,6 +39,7 @@ try:
     _cryptography = True
 except ImportError:  # pragma: no cover
     _cryptography = False
+import six
 
 from . import utils
 import fedmsg.crypto
@@ -144,6 +145,21 @@ def validate(message, ssldir=None, **config):
     Returns:
         bool: True of the message passes validation, False otherwise.
     """
+    for field in ['signature', 'certificate']:
+        if field not in message:
+            _log.warn('No %s field found.', field)
+            return False
+        if not isinstance(message[field], six.text_type):
+            _log.error('msg[%r] is not a unicode string' % field)
+            try:
+                # Make an effort to decode it, it's very likely utf-8 since that's what
+                # is hardcoded throughout fedmsg. Worst case scenario is it'll cause a
+                # validation error when there shouldn't be one.
+                message[field] = message[field].decode('utf-8')
+            except UnicodeError as e:
+                _log.error("Unable to decode the message '%s' field: %s", field, str(e))
+                return False
+
     try:
         signature = base64.b64decode(message['signature'])
         certificate = base64.b64decode(message['certificate'])

--- a/fedmsg/crypto/x509_ng.py
+++ b/fedmsg/crypto/x509_ng.py
@@ -160,12 +160,8 @@ def validate(message, ssldir=None, **config):
                 _log.error("Unable to decode the message '%s' field: %s", field, str(e))
                 return False
 
-    try:
-        signature = base64.b64decode(message['signature'])
-        certificate = base64.b64decode(message['certificate'])
-    except KeyError:
-        return False
-
+    signature = base64.b64decode(message['signature'])
+    certificate = base64.b64decode(message['certificate'])
     message = fedmsg.crypto.strip_credentials(message)
 
     crl_file = None

--- a/fedmsg/tests/crypto/test_x509.py
+++ b/fedmsg/tests/crypto/test_x509.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # This file is part of fedmsg.
 # Copyright (C) 2012 - 2017 Red Hat, Inc.
 #

--- a/fedmsg/tests/crypto/test_x509.py
+++ b/fedmsg/tests/crypto/test_x509.py
@@ -189,6 +189,19 @@ class X509BaseTests(TestCase):
 
         self.assertFalse(self.validate(signed, **self.config))
 
+    def test_text_validate(self):
+        """Assert unicode-type signatures/certificates work."""
+        signed = self.sign({'topic': 'mytopic', 'message': 'so secure'}, **self.config)
+
+        # This assertion will fail when the sign API changes to return text types, at
+        # which point this test should drop the decode step.
+        self.assertTrue(isinstance(signed['signature'], six.binary_type))
+        self.assertTrue(isinstance(signed['certificate'], six.binary_type))
+        signed['signature'] = signed['signature'].decode('utf-8')
+        signed['certificate'] = signed['certificate'].decode('utf-8')
+
+        self.assertTrue(self.validate(signed, **self.config))
+
 
 @skipIf(not _cryptography, "cryptography/pyOpenSSL are missing.")
 class X509CryptographyTests(X509BaseTests):

--- a/fedmsg/tests/crypto/test_x509.py
+++ b/fedmsg/tests/crypto/test_x509.py
@@ -85,6 +85,18 @@ class X509BaseTests(TestCase):
         self.assertTrue('signature' in signed)
         self.assertTrue('certificate' in signed)
 
+    @expectedFailure
+    def test_signature_text(self):
+        """Assert signature fields are unicode text."""
+        signed = self.sign({'my': 'message'}, **self.config)
+        self.assertTrue(isinstance(signed['signature'], six.text_type))
+
+    @expectedFailure
+    def test_certificate_text(self):
+        """Assert signing a message inserts the certificate and a signature."""
+        signed = self.sign({'my': 'message'}, **self.config)
+        self.assertTrue(isinstance(signed['certificate'], six.text_type))
+
     def test_sign_and_verify(self):
         """Assert signed messages are verified."""
         signed = self.sign({'my': 'message'}, **self.config)


### PR DESCRIPTION
I just noticed this in the logs of program driven by `fedmsg.tail_messages`.
The signature was unicode, and so this type check failed every time.

This seems to have been inadvertently broken in f0553d285e586dc48f1a244b81f1517551d469ee ?