### PR TITLE
ZMQMessage isn't iterable, use __dict__

### DIFF
--- a/fedmsg/consumers/__init__.py
+++ b/fedmsg/consumers/__init__.py
@@ -286,7 +286,7 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
 
         # Pass along headers if present.  May be useful to filters or
         # fedmsg.meta routines.
-        if 'headers' in message.__dict__ and 'body' in message.__dict__:
+        if isinstance(message, dict) and 'headers' in message and 'body' in message:
             message['body']['headers'] = message['headers']
 
         if hasattr(self, "replay_name"):

--- a/fedmsg/consumers/__init__.py
+++ b/fedmsg/consumers/__init__.py
@@ -286,7 +286,7 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
 
         # Pass along headers if present.  May be useful to filters or
         # fedmsg.meta routines.
-        if 'headers' in message and 'body' in message:
+        if 'headers' in message.__dict__ and 'body' in message.__dict__:
             message['body']['headers'] = message['headers']
 
         if hasattr(self, "replay_name"):


### PR DESCRIPTION
This was flooding logs with traces after we did updates on 2017-08-09. This is the hotfix I came up with, but if it's fixed another way that's fine with me too. Just wanted to get this out there.