### PR TITLE
Add missing space to error message

### DIFF
--- a/fedmsg/core.py
+++ b/fedmsg/core.py
@@ -333,7 +333,7 @@ class FedMsgContext(object):
             import moksha.hub
             # First, a quick sanity check.
             if not getattr(moksha.hub, '_hub', None):
-                raise AttributeError("Unable to publish non-zeromq msg"
+                raise AttributeError("Unable to publish non-zeromq msg "
                                      "without moksha-hub initialization.")
             # Let moksha.hub do our work.
             moksha.hub._hub.send_message(


### PR DESCRIPTION
Add a missing space in error message in FedMsgContext.publish when
moksha-hub has not been initialized.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

Problem is 

```
AttributeError: Unable to publish non-zeromq msgwithout moksha-hub initialization.
                                             ~~~~~~~~~~
```

it is fixed

```
AttributeError: Unable to publish non-zeromq msg without moksha-hub initialization.
```