### PR TITLE
Remove Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ env:
     - PYTHONWARNINGS=always::DeprecationWarning
 matrix:
   include:
-    - python: "2.6"
-      env: TOXENV=py26
     - python: "2.7"
       env: TOXENV=py27
     - python: "2.7"

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,8 @@ Backwards incompatible changes
   `systemd unit files <https://github.com/fedora-infra/fedmsg/tree/1.0.0/initsys>`_
   are available in the git repository (`#470 <https://github.com/fedora-infra/fedmsg/pull/470>`_).
 
+* Python 2.6 is no longer supported (`#469 <https://github.com/fedora-infra/fedmsg/pull/469>`_).
+
 
 0.19.1
 ======

--- a/setup.py
+++ b/setup.py
@@ -101,15 +101,7 @@ tests_require = [
 
 if sys.version_info[0] == 2:
     tests_require.append('mock')
-    if sys.version_info[1] <= 6:
-        install_requires.extend([
-            'argparse',
-            'ordereddict',
-            'logutils',
-        ])
-        tests_require.extend([
-            'unittest2',
-        ])
+
 
 setup(
     name='fedmsg',
@@ -126,7 +118,6 @@ setup(
         'License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,10 +4,5 @@ pygments
 psutil
 sqlalchemy
 mock
-argparse; python_version <= '2.6'
-ordereddict; python_version <= '2.6'
-logutils; python_version <= '2.6'
-unittest2; python_version <= '2.6'
-Twisted==12.2; python_version <= '2.6'
 flake8
 click

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py26,py27,py34,py35,py36,m2crypto,docs
+envlist = lint,py27,py34,py35,py36,m2crypto,docs
 
 [testenv]
 passenv = TRAVIS TRAVIS_* FEDMSG_NETWORK
@@ -23,13 +23,6 @@ extras =
     crypto
     commands
     consumers
-
-[testenv:py26]
-extras =
-    commands
-    consumers
-    crypto_ng
-    crypto
 
 [testenv:py27]
 extras =


### PR DESCRIPTION
See https://github.com/fedora-infra/fedmsg/issues/418 and https://github.com/mokshaproject/moksha/pull/48.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>