### PR TITLE
Mark the wheel as universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
The package is both Python 2 and Python 3 compatible without using 2to3
and we have no C extensions so we can safely build universal wheels.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>