### PR TITLE
Fix the Python 3 incompatibility in crypto utils

### DIFF
--- a/fedmsg/crypto/utils.py
+++ b/fedmsg/crypto/utils.py
@@ -98,7 +98,7 @@ def validate_policy(topic, signer, routing_policy, nitpicky=False):
             return True
 
 
-def _load_remote_cert(location, cache, cache_expiry, tries=0, **config):
+def _load_remote_cert(location, cache, cache_expiry, tries=1, **config):
     """Get a fresh copy from fp.o/fedmsg/crl.pem if ours is getting stale.
 
     Return the local filename.
@@ -132,18 +132,12 @@ def _load_remote_cert(location, cache, cache_expiry, tries=0, **config):
         (cache_expiry and time.time() - modtime > cache_expiry)
     ):
         try:
-            response = requests.get(location)
+            with requests.Session() as session:
+                session.mount('http://', requests.adapters.HTTPAdapter(max_retries=tries))
+                session.mount('https://', requests.adapters.HTTPAdapter(max_retries=tries))
+                response = session.get(location, timeout=30)
             with open(cache, 'w') as f:
                 f.write(response.content)
-        except requests.exceptions.ConnectionError:
-            if tries < 3:
-                _log.warn("Could not access %r.  Trying again." % location)
-                time.sleep(1)  # Take a nap to see if the network settles down.
-                return _load_remote_cert(
-                    location, cache, cache_expiry, tries + 1, **config)
-            else:
-                _log.error("Could not access %r" % location)
-                raise
         except IOError:
             # If we couldn't write to the specified cache location, try a
             # similar place but inside our home directory instead.

--- a/fedmsg/crypto/utils.py
+++ b/fedmsg/crypto/utils.py
@@ -98,7 +98,7 @@ def validate_policy(topic, signer, routing_policy, nitpicky=False):
             return True
 
 
-def _load_remote_cert(location, cache, cache_expiry, tries=1, **config):
+def _load_remote_cert(location, cache, cache_expiry, tries=3, **config):
     """Get a fresh copy from fp.o/fedmsg/crl.pem if ours is getting stale.
 
     Return the local filename.
@@ -109,7 +109,7 @@ def _load_remote_cert(location, cache, cache_expiry, tries=1, **config):
         location (str): The URL where the certificate is hosted.
         cache (str): The absolute path where the certificate should be stored.
         cache_expiry (int): How long the cache should be considered fresh, in seconds.
-        tries (int): The number of times to attempt downloading the certificate.
+        tries (int): The number of times to attempt to retry downloading the certificate.
 
     """
     alternative_cache = os.path.expanduser("~/.local" + cache)
@@ -137,7 +137,7 @@ def _load_remote_cert(location, cache, cache_expiry, tries=1, **config):
                 session.mount('https://', requests.adapters.HTTPAdapter(max_retries=tries))
                 response = session.get(location, timeout=30)
             with open(cache, 'w') as f:
-                f.write(response.content)
+                f.write(response.text)
         except IOError:
             # If we couldn't write to the specified cache location, try a
             # similar place but inside our home directory instead.

--- a/fedmsg/tests/base.py
+++ b/fedmsg/tests/base.py
@@ -1,0 +1,31 @@
+import os
+import unittest
+
+import vcr
+
+#: The directory where test fixtures should be placed.
+FIXTURES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), 'fixtures/'))
+
+#: The directory where all the test x509 certificates are stored.
+SSLDIR = os.path.abspath(os.path.join(os.path.dirname(__file__), 'test_certs/keys/'))
+
+
+class FedmsgTestCase(unittest.TestCase):
+    """Base test case that does useful setup/teardown for all fedmsg tests."""
+
+    def setUp(self):
+        """
+        Set up the test environment.
+
+        VCR is set up for all tests using the FIXTURES_DIR to store the recordings.
+
+        .. note:: VCR is set to ``record_mode='none'`` so tests fail if a real request
+            is made. This is helpful to ensure tests always use the recording, but you
+            will need to set it to ``record_mode='once'`` when a new recording is
+            required.
+        """
+        my_vcr = vcr.VCR(
+            cassette_library_dir=os.path.join(FIXTURES_DIR, 'vcr'), record_mode='none')
+        self.vcr = my_vcr.use_cassette(self.id())
+        self.vcr.__enter__()
+        self.addCleanup(self.vcr.__exit__, None, None, None)

--- a/fedmsg/tests/consumers/test_consumers.py
+++ b/fedmsg/tests/consumers/test_consumers.py
@@ -29,11 +29,7 @@ import mock
 
 from fedmsg import crypto
 from fedmsg.consumers import FedmsgConsumer
-from fedmsg.tests.crypto.test_x509 import SSLDIR
-
-
-FIXTURES_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '../fixtures/'))
+from fedmsg.tests.base import SSLDIR, FIXTURES_DIR
 
 
 class DummyConsumer(FedmsgConsumer):

--- a/fedmsg/tests/crypto/test_x509.py
+++ b/fedmsg/tests/crypto/test_x509.py
@@ -44,10 +44,7 @@ except ImportError:
     from unittest2 import skipIf, TestCase, expectedFailure
 
 from fedmsg import crypto  # noqa: E402
-
-
-SSLDIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '../test_certs/keys/'))
+from fedmsg.tests.base import SSLDIR  # noqa: E402
 
 
 @skipIf(not (_m2crypto or _cryptography), "Neither M2Crypto nor Cryptography available")

--- a/fedmsg/tests/fixtures/vcr/fedmsg.tests.crypto.test_utils.LoadRemoteCertTests.test_remote_cert
+++ b/fedmsg/tests/fixtures/vcr/fedmsg.tests.crypto.test_utils.LoadRemoteCertTests.test_remote_cert
@@ -1,0 +1,43 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://fedoraproject.org/fedmsg/ca.crt
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WUy5KiShCG9/UUZ290NCioLOvG1QKLq7BTaEFpRe3WAp5+UKOnZ86Z1ZnaVEQG
+        +Wfy5V/58jIcRA3L/QdTP7R0C8OQ3oMvgFkW6XqMYR+UUFgIlpYNPZebdbHUW1VnUDJwcDYCazMh
+        nCLEI8gso2T8Q2CeEhBzblBhx1FPFwzWBpQjihHDYc1aSqCHSjdGMA+RbFcbIz5l47LVexg/400I
+        SJ29Z4bWpQHi+UE7Z4krMT4XZFAfxBdUZIcs8T/zcd6SHrrPRBaiwz1P7kHW0+W9zXtlx2dGdojr
+        zco9siAVNkxtp8ms6pa7kNdIr4pqSDptanQXveUHXYCvqouD1mU9fNOF1LI9nLAw6oZbuCRbD7Hu
+        GWM/Y18cAH62+r85gDuIv+EA7iD+hgO4g/idA0bHR5X6XNU7QxMSgpzqcPiTPYeiTGtcphR+FrJN
+        PusJmE/G4xM+LdBieRXXbWrURTmVlqv9O7nZ7eUsNWFOm6XCZTFauWRaK6NR2W877ey+RyFNgXeS
+        J+7H2uj223rqONcg3ozGK0W77W0rfSVFPJ1F/Saq0/SsNotTTw6zTJNaxboJiJZBClw+qqp1s/DE
+        cRooTrEtfCyNosYithOPbNh0EoaCQrj28MBAlCXVGXrwKkjJE4CQf+H6RaXlzk7eikzlKxlWkhMe
+        5xEkGMn3SfjSHlmmyyzTKf/1PfgtwTHQ6RygZgDZkG9PoIrhOGYt7qH9HGEZwlolzIcCkPIxa5OK
+        IkiT9n2dFA3zc6E/PeBQoRpP29IyMu3b+hDvC/I9doDbX+b+bR7yR/Pg+ucjGrxzYJgb4Je3bkM/
+        XaVD0jpR4UN0Ylf5V1WsDl28YczJPkKqGbb5mx9CBu7Kps8oCiGB3Hz90wKBioGgs4+81cWA1kku
+        t9dNcfBo0W0YGC9YoLl6DpXJfHJ0ikpJ0cUbK03mjXsoa0kQxJzOtriTXnf6PGiVmafttrVpWqTO
+        bzPg2yOVRNMPv44IuShaVM50vfPn8cqzQyWKZvGucmOZ1eV7gpfKpdtbSS6uqqoYYV9qCDDzYiTa
+        FQVuqLfS6yls+yN4rEvqkv+u0B/hSo9jXwUAAA==
+    headers:
+      Accept-Ranges: [bytes]
+      AppServer: [proxy08.fedoraproject.org]
+      AppTime: [D=917]
+      Connection: [Keep-Alive]
+      Content-Encoding: [gzip]
+      Content-Length: ['826']
+      Date: ['Wed, 06 Sep 2017 14:35:42 GMT']
+      ETag: ['"55f-52243d9164097-gzip"']
+      Keep-Alive: ['timeout=15, max=500']
+      Last-Modified: ['Sat, 17 Oct 2015 02:41:23 GMT']
+      Server: [Apache/2.4.6 (Red Hat Enterprise Linux)]
+      Vary: ['Accept-Encoding,User-Agent']
+    status: {code: 200, message: OK}
+version: 1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,5 +4,6 @@ pygments
 psutil
 sqlalchemy
 mock
+vcrpy
 flake8
 click


### PR DESCRIPTION
Write the downloaded file as text since the file is opened in text mode.
    
fixes #476
