### PR TITLE
Alter how the tests determine if cryptography is available

### DIFF
--- a/fedmsg/tests/crypto/test_x509.py
+++ b/fedmsg/tests/crypto/test_x509.py
@@ -24,26 +24,14 @@ import os
 import mock
 import six
 
-_m2crypto, _cryptography = False, False
-try:
-    import M2Crypto     # noqa: F401
-    import m2ext        # noqa: F401
-    _m2crypto = True
-except ImportError:
-    pass
-try:
-    import cryptography  # noqa
-    import OpenSSL  # noqa
-    _cryptography = True
-except ImportError:
-    pass
-
 try:
     from unittest import skipIf, TestCase, expectedFailure
 except ImportError:
     from unittest2 import skipIf, TestCase, expectedFailure
 
 from fedmsg import crypto  # noqa: E402
+from fedmsg.crypto.x509 import _m2crypto
+from fedmsg.crypto.x509_ng import _cryptography
 from fedmsg.tests.base import SSLDIR  # noqa: E402
 
 


### PR DESCRIPTION
Rather than re-importing cryptography and m2crypto to detect what tests
to run in the test module, just import from the x509_ng module. This
fixes issues when running the tests with an old pyOpenSSL library that
doesn't provide the APIs we need.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>