### PR TITLE
Remove cryptography from the main install requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ install_requires = [
     'requests',
     'six',
     'arrow',           # not *necessarily* required
-    'cryptography',    # for message signing
 ]
 extras_require = {
     'crypto': [


### PR DESCRIPTION
Cryptography is optional and part of the 'crypto_ng' extra. In the
future it may become a default requirement, but for now only require it
in the extras section.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>