### PR TITLE
Add a broker service and a publish API

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -11,10 +11,17 @@ on is not documented here, it may change without warning in a minor release.
 Python
 ======
 
+.. note:: This API is intended to replace the old fedmsg API (found below) and
+        is still experimental. As such, it may change without a major release of
+        fedmsg. However, all changes will be clearly noted in the release notes.
+        Please provide any feedback you have!
+
+.. automodule:: fedmsg.api
+
 .. _api-send-receive:
 
 Sending and Receiving Messages
-------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: fedmsg
     :members: init, destroy, publish, tail_messages

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,10 +16,15 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
 import logging
+
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
 
 # moksha logs warnings if qpid is missing, but we don't care
 logging.getLogger('moksha.hub').setLevel(logging.ERROR)

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -681,3 +681,37 @@ consumers. If it is not specified, the Moksha hub will listen to all topics decl
 fedmsg consumers.
 
 There is no default for this setting.
+
+
+.. _broker-config:
+
+Broker Configuration
+====================
+
+The broker is configured with the following keys
+
+.. _conf-submission_endpoint:
+
+submission_endpoint
+-------------------
+
+The ZeroMQ endpoint to assign to the submission socket. This is in the format
+``<transport>://<address>``. The transport should either be ``ipc`` or ``tcp``.
+
+Default: An IPC socket in the user's data directory. On UNIX platforms this is
+``~/.local/share/fedmsg/submission.socket``.
+
+.. _conf-publishers:
+
+publishers
+----------
+
+A dictionary of configuration values where the key is a publisher's name and the
+value is a dictionary of keyword arguments for that publisher.
+
+For example::
+
+    'publishers': {
+        'zmq': {'publish_endpoint': 'tcp://*:9941'},
+        'legacy_zmq': {'publish_endpoint': 'tcp://*:9940'},
+    }

--- a/doc/publishing.rst
+++ b/doc/publishing.rst
@@ -1,6 +1,17 @@
+.. _publishing:
+
 ==========
 Publishing
 ==========
+
+.. _legacy-publishing:
+
+Publishing without a Broker
+===========================
+
+.. warning:: The APIs described in this section have been deprecated and will be
+    removed in a future release. You should use the APIs described in
+    :ref:`publishing`.
 
 Before you start publishing messages, it is recommended that you call
 :func:`fedmsg.init`. This should be done from every Python thread you intend
@@ -66,3 +77,55 @@ of endpoints that fedmsg can bind to. Each Python thread, when :func:`fedmsg.ini
 is called, iterates through the list and attempts to bind to each address. If it
 is unable to bind to any address, an :class:`IOError` is raised. The solution is
 to add more endpoints to the configuration.
+
+
+Publishing with the Broker
+==========================
+
+.. note:: This describes the new publishing API was added in fedmsg version 1.1.0.
+    This API is still experimental and may change without a major release of fedmsg.
+    However, all changes will be clearly noted in the change log. Please provide
+    any feedback you have on this API! For documentation on the old approach,
+    see :ref:`legacy-publishing`.
+
+Before you can publish messages, you need to start the fedmsg broker service.
+
+Fedmsg Broker
+=============
+
+The broker service binds a socket and clients submit messages to the service for
+publication. By default, the service uses the inter-process communication transport
+and is run on the same host as the clients, but it can also use TCP and run on a
+different host.
+
+The fedmsg broker can be started using the provided systemd unit files, or run
+in the foreground using::
+
+    $ fedmsg broker
+
+To change the broker configuration, either provide the configuration values using
+the command line interface's flags (use ``fedmsg broker --help`` for the list of
+available flags) or set the :ref:`broker-config` options in fedmsg's
+configuration files.
+
+
+Sending a Message
+=================
+
+Once the fedmsg broker is running, you should be able to publish a message. However,
+you should first set up a subscribing socket to actually _see_ the message::
+
+    >>> import zmq
+    >>> context = zmq.Context()
+    >>> sock = context.socket(zmq.SUB)
+    >>> sock.setsockopt(zmq.SUBSCRIBE, b'')
+    >>> sock.connect('tcp://127.0.0.1:9940')
+    >>> sock.recv_multipart()  # This will block until you go to the next step
+
+Now send the message::
+
+    >>> from fedmsg.api import publish
+    >>> publish(topic=u'demo.success', body={u'Hello': u'World!'})
+
+You'll see the broker announce it received your message and sent it, and you'll
+see it pop up in the terminal you're listening on!

--- a/fedmsg/api.py
+++ b/fedmsg/api.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of fedmsg.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""The main interface for fedmsg."""
+from __future__ import absolute_import
+import logging
+import json
+
+import six
+import zmq
+
+from . import config, exceptions
+from .broker.service import SUBMISSION_V1
+
+_log = logging.getLogger(__name__)
+
+
+def publish(topic=u'', headers=None, body=None, timeout=10):
+    """
+    Publish a fedmsg via the fedmsg broker service.
+
+    This API blocks until the broker responses with either success or failure.
+
+    Args:
+        topic (str): A unicode string to use as the message topic. If ``topic_prefix``
+            is set it will be prepended to this topic.
+        headers (dict): Optional message headers.
+        body (dict): A JSON-serializable dictionary.
+        timeout (float, int): The time to wait, in seconds, for a response
+            from the fedmsg broker. Set to -1 for infinite timeout.
+
+    Raises:
+        ValueError: If the topic is not a unicode string.
+        exceptions.ReadTimeout: If there's no response from the broker. Note that
+            the message could have been published even if this exception is raised.
+        exceptions.WriteTimeout: If no connection can be established to the broker.
+
+    Returns:
+        list: The multi-part response from the broker.
+    """
+    if not isinstance(topic, six.text_type):
+        raise ValueError('Message topic must be a unicode string')
+
+    # -1 means block forever, don't multiply by 1000 to make it seconds
+    if not timeout == -1:
+        timeout *= 1000
+
+    if headers is None:
+        headers = {}
+
+    if body is None:
+        body = {}
+
+    # Before sending the message over the wire, we need to encode it to bytes.
+    # We don't allow a configurable encoding and force it to be utf-8.
+    topic = topic.encode('utf-8')
+    headers = json.dumps(headers).encode('utf-8')
+    body = json.dumps(body).encode('utf-8')
+    _log.info('Publishing message to the "%r" topic', topic)
+
+    context = zmq.Context.instance()
+    with context.socket(zmq.REQ) as request_socket:
+        # Only queue messages for delivery if there's an active connection.
+        # Failing to do this means the message lands in the local queue for
+        # delivery and it's not clear to the user that the message got sent.
+        request_socket.setsockopt(zmq.IMMEDIATE, 1)
+        request_socket.setsockopt(zmq.RCVTIMEO, timeout)
+        request_socket.setsockopt(zmq.SNDTIMEO, timeout)
+        request_socket.connect(config.conf['submission_endpoint'])
+
+        try:
+            request_socket.send_multipart([SUBMISSION_V1, topic, headers, body])
+        except zmq.Again:
+            raise exceptions.WriteTimeout(
+                'Unable to write to "{}" in {} milliseconds'.format(
+                    config.conf['submission_endpoint'], timeout))
+        try:
+            return request_socket.recv_multipart()
+        except zmq.Again:
+            raise exceptions.ReadTimeout(
+                'No response from the fedmsg broker at "{}" in {} seconds'.format(
+                    config.conf['submission_endpoint'], timeout))

--- a/fedmsg/broker/__init__.py
+++ b/fedmsg/broker/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of fedmsg.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA

--- a/fedmsg/broker/publishers.py
+++ b/fedmsg/broker/publishers.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of fedmsg.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""
+The fedmsg publishers.
+
+fedmsg publishers accept messages from the publishing service and are responsible
+for sending the message over ZeroMQ, AMQP, carrier pigeon, etc.
+"""
+from __future__ import absolute_import
+
+import logging
+import json
+import threading
+
+import zmq
+
+_log = logging.getLogger(__name__)
+
+
+class Publisher(threading.Thread):
+    """
+    The base class for fedmsg publishers.
+
+    Each publisher should implement the interface defined by this class.
+    """
+
+    def __init__(self, context=None, **kwargs):
+        """
+        Publishers should perform any setup required to publish messages here. It
+        is acceptable to use blocking APIs during the setup.
+
+        Args:
+            context (zmq.Context): The ZeroMQ context to use when creating the
+                pair socket. If one is not provided, the default instance is used.
+            **kwargs: The configuration settings for the publisher. The keys passed
+                depend on the publisher. Users will be able to set the configuration
+                in the fedmsg configuration file.
+        """
+        super(Publisher, self).__init__()
+        self.daemon = True
+        context = context or zmq.Context.instance()
+        self.pair = context.socket(zmq.PAIR)
+        self.pair_address = 'inproc://' + type(self).__name__
+        self.pair.bind(self.pair_address)
+
+    def run(self):
+        """
+        Receive messages to send over the ZeroMQ pair socket and hand them to the
+        :meth:`publish` method. Sub-classes should not need to override this method.
+        """
+        while True:
+            try:
+                topic, headers, body = self.pair.recv_multipart()
+            except ValueError as e:
+                _log.error('Unable to unpack message from pair socket: %s', e)
+                continue
+            try:
+                topic = topic.decode('utf-8')
+                headers = headers.decode('utf-8')
+                body = body.decode('utf-8')
+                if len(headers):
+                    headers = json.loads(headers)
+                if len(body):
+                    body = json.loads(body)
+            except (ValueError, UnicodeDecodeError) as e:
+                _log.exception('Unable to decode message %r; not sending via %s',
+                               [topic, headers, body], type(self).__name__)
+                continue
+
+            try:
+                self.publish(topic, headers, body)
+                result = {'publisher': type(self).__name__, 'result': 'success', 'reason': None}
+            except Exception as e:
+                _log.exception('An unexpected exception occurred publishing %r via %s',
+                               [topic, headers, body], type(self).__name__)
+                result = {'publisher': type(self).__name__, 'result': 'failure', 'reason': str(e)}
+
+            self.pair.send(json.dumps(result).encode('utf-8'))
+
+    def publish(self, topic, headers, body):
+        """
+        This method is called when a message is submitted by a user for publication.
+
+        How the topic, headers, and body are published are dependent on the type
+        of publisher.
+
+        Each :class:`Publisher` runs in a separate Python thread and should block until the
+        message delivery has been either confirmed or failed with the configured timeout.
+
+        Args:
+            topic (six.text_type): The ZeroMQ topic this message was sent to as a unicode string.
+                This may contain any unicode character and implementations must account for that.
+            headers (dict): A set of message headers. Each key and value will be a unicode string.
+            body (dict): The message body.
+        """
+        raise NotImplementedError
+
+
+class ZeroMqPublisher(Publisher):
+    """
+    Publisher that sends messages via a ZeroMQ PUB socket.
+
+    Args:
+        context (zmq.Context): The ZeroMQ context to use when creating the
+            pair socket. If one is not provided, the default instance is used.
+        publish_endpoint (str): The endpoint to bind the publishing socket to in
+            standard ZeroMQ format ('tcp://127.0.0.1:9940', 'ipc:///path/to/sock', etc).
+    """
+
+    publisher_version = b'FEDPUB1'
+
+    def __init__(self, context=None, publish_endpoint=None):
+        super(ZeroMqPublisher, self).__init__(context=context)
+
+        context = context or zmq.Context.instance()
+        self.publish_endpoint = publish_endpoint
+        self.pub_socket = context.socket(zmq.PUB)
+        _log.info('Binding to %s for ZeroMQ publication', publish_endpoint)
+        self.pub_socket.bind(publish_endpoint)
+
+    def publish(self, topic, headers, body):
+        """
+        Publish messages to a ZeroMQ PUB socket.
+
+        Args:
+            topic (six.text_type): The ZeroMQ topic this message was sent to as a unicode string.
+                This may contain any unicode character and implementations must account for that.
+            headers (dict): A set of message headers. Each key and value will be a unicode string.
+            body (dict): The message body.
+        """
+
+        _log.info('Publishing message on "%s" to the ZeroMQ PUB socket "%s"',
+                  topic, self.publish_endpoint)
+        topic = topic.encode('utf-8')
+        headers = json.dumps(headers).encode('utf-8')
+        body = json.dumps(body).encode('utf-8')
+        multipart_message = [topic, self.publisher_version, headers, body]
+        self.pub_socket.send_multipart(multipart_message)
+
+
+class LegacyZeroMqPublisher(ZeroMqPublisher):
+    """
+    Publisher that sends messages via a ZeroMQ PUB socket using the v1 fedmsg
+    wire format.
+
+    Args:
+        context (zmq.Context): The ZeroMQ context to use when creating the
+            pair socket. If one is not provided, the default instance is used.
+        publish_endpoint (str): The endpoint to bind the publishing socket to in
+            standard ZeroMQ format ('tcp://127.0.0.1:9940', 'ipc:///path/to/sock', etc).
+    """
+
+    def publish(self, topic, headers, body):
+        """
+        Publish messages to a ZeroMQ PUB socket in the legacy format.
+
+        The legacy format is a two part message over a PUB socket - the first
+        is the topic and the second is an arbitrary JSON object.
+
+        Args:
+            topic (six.text_type): The ZeroMQ topic this message was sent to as a unicode string.
+                This may contain any unicode character and implementations must account for that.
+            headers (dict): A set of message headers. Each key and value will be a unicode string.
+            body (dict): The message body.
+        """
+
+        _log.info('Publishing message on "%s" to the ZeroMQ PUB socket "%s"',
+                  topic, self.publish_endpoint)
+        topic = topic.encode('utf-8')
+        # There were no headers in the first version of fedmsg, they got placed in the body
+        body[u'headers'] = headers
+        body = json.dumps(body).encode('utf-8')
+        multipart_message = [topic, body]
+        self.pub_socket.send_multipart(multipart_message)

--- a/fedmsg/broker/service.py
+++ b/fedmsg/broker/service.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of fedmsg.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""
+The fedmsg broker service.
+
+The broker binds to a submission port and relays incoming messages to publishers
+which are responsible for publishing the message to the world via ZeroMQ, AMQP,
+carrier pigeon, etc.
+"""
+from __future__ import absolute_import
+
+import logging
+import json
+import os
+import signal
+
+import zmq
+
+from .publishers import ZeroMqPublisher, LegacyZeroMqPublisher
+
+
+SUBMISSION_V1 = b'FSUBMIT1'
+ERROR_MALFORMED = b'ERROR_MALFORMED'
+
+_log = logging.getLogger(__name__)
+
+
+class BrokerService(object):
+    """
+    The fedmsg broker service.
+
+    This service binds to the given submission socket using a ZeroMQ Reply socket
+    where clients can send publishing requests using a ZeroMQ Request socket. When
+    all publishers have announced success or failure, the client is informed.
+
+    The fedmsg submission message is a multi-part message that builds on top of
+    the ZeroMQ `REQREP`_ RFC. The message should be made up of 4 data frames:
+
+        * Frame 0: The fedmsg submission protocol version string. This is an ASCII-encoded
+          string that indicates the protocol version being used. There is currently only
+          one version, "FSUBMIT1".
+        * Frame 1: The message topic as a UTF-8-encoded string.
+        * Frame 2: A set of key-value pairs to use as the message headers. This should be
+          a JSON-serialized object encoded with UTF-8.
+        * Frame 3: The message body as a JSON-serialized object encoded with UTF-8.
+
+
+    .. _REQREP: https://rfc.zeromq.org/spec:28/REQREP
+
+    Args:
+        submission_socket (str): A ZeroMQ socket to bind to for message submission.
+        publisher_configs (list): A list of dictionaries containing publisher configurations.
+        context (zmq.Context): The ZeroMQ context to use when creating sockets. If one is
+            not provided, one will be created.
+    """
+    # Map config names to classes
+    _publishers = {
+        'zmq': ZeroMqPublisher,
+        'legacy_zmq': LegacyZeroMqPublisher,
+    }
+
+    def __init__(self, submission_endpoint, publisher_configs, context=None):
+        self.run = False
+        self.context = context or zmq.Context.instance()
+        self.submission_endpoint = submission_endpoint
+        self.submission_socket = self.context.socket(zmq.REP)
+        self.submission_socket.setsockopt(zmq.RCVTIMEO, 1500)
+
+        # Create the publishers and their pair sockets
+        self.publishers = [
+            (self._publishers[name](context=self.context, **conf), self.context.socket(zmq.PAIR))
+            for name, conf in publisher_configs.items() if name in self._publishers
+        ]
+
+    def start(self):
+        """
+        Start the fedmsg broker.
+
+        This will block until the process receives a SIGINT or SIGTERM signal.
+        """
+        _log.info('Starting the fedmsg broker service')
+        if self.submission_endpoint.startswith('ipc://'):
+            socket_dir = os.path.dirname(self.submission_endpoint.split('ipc://')[1])
+            if not os.path.exists(socket_dir):
+                _log.info('%s does not exist, creating it for the submission endpoint', socket_dir)
+                os.makedirs(socket_dir, mode=0o775)
+        _log.info('Binding to %s as the fedmsg publisher submission socket',
+                  self.submission_endpoint)
+        self.submission_socket.bind(self.submission_endpoint)
+
+        # Since this method blocks, let users halt us with a signal handler
+        def _handler(signum, frame):
+            """
+            Signal handler that gracefully shuts down the broker.
+
+            Args:
+                signum (int): The signal this process received.
+                frame (frame): The current stack frame (unused).
+            """
+            if signum in (signal.SIGTERM, signal.SIGINT):
+                _log.info('Halting the fedmsg broker service')
+                self.running = False
+
+        signal.signal(signal.SIGTERM, _handler)
+        signal.signal(signal.SIGINT, _handler)
+
+        self.running = True
+        for pub, sock in self.publishers:
+            pub.start()
+            sock.connect(pub.pair_address)
+        _log.info('fedmsg broker started successfully')
+
+        self._run()
+
+    def _run(self):
+        """
+        The main service loop.
+
+        This loop is halted when the SIGINT/SIGTERM signal is received and handled.
+        """
+        while self.running:
+            try:
+                multipart_message = self.submission_socket.recv_multipart()
+                _log.debug('Received message submission: %r', multipart_message)
+            except zmq.Again:
+                # The socket as a receive timeout of 1.5 seconds so we can check
+                # to see if we've been asked to halt.
+                continue
+
+            if len(multipart_message) != 4 or multipart_message[0] != SUBMISSION_V1:
+                # Later we can switch on the submission version to allow for graceful
+                # handling of protocol changes.
+                _log.error('The submitted message, "%r", is malformed', multipart_message)
+                self.submission_socket.send_multipart([SUBMISSION_V1, ERROR_MALFORMED])
+                continue
+
+            for _, publish_pair in self.publishers:
+                publish_pair.send_multipart(multipart_message[1:])
+                _log.info('Sent message to %s', _)
+            results = []
+            for publisher, publish_pair in self.publishers:
+                result = publish_pair.recv()
+                results.append(json.loads(result.decode('utf-8')))
+                _log.info('%s finished publishing and reported %s', publisher, result)
+            self.submission_socket.send_multipart(
+                [SUBMISSION_V1, json.dumps(results).encode('utf-8')])
+
+        self._close()
+
+    def _close(self, timeout=15):
+        """
+        Close all the sockets and shut down the publishers.
+
+        Each publisher runs in a daemon thread so even if they don't successfully
+        join we can halt, although this doesn't guarantee a clean shutdown.
+
+        Args:
+            timeout (float): The amount of time in seconds to wait on the thread
+                to join. Setting this to ``None`` will cause this method to block
+                (potentially indefinitely) until all threads close.
+        """
+        self.submission_socket.close()
+        for pub, sock in self.publishers:
+            _log.info('Signaling the %r publisher to shut down', pub)
+            sock.send(b'HALT')
+            pub.join(timeout=timeout)
+            if pub.is_alive():
+                _log.error('The %r publisher failed to halt after %r seconds, '
+                           'shutting down forcibly!', pub, timeout)
+            sock.close()
+        _log.info('Halted the fedmsg broker')

--- a/fedmsg/cli/__init__.py
+++ b/fedmsg/cli/__init__.py
@@ -1,0 +1,34 @@
+"""
+The ``fedmsg`` `Click`_ CLI.
+
+.. note:: Do not add commands to this module - each command should have its
+          own module.
+
+.. _Click: http://click.pocoo.org/
+"""
+import click
+
+from fedmsg import config
+
+
+@click.group()
+@click.option('--conf', envvar='FEDMSG_CONFIG')
+def cli(conf):
+    """
+    The fedmsg command line interface.
+
+    This can be used to run fedmsg services, check on the status of those services,
+    publish messages, and more.
+
+    Note: This command-line interface is experimental and may change without a major
+    release.
+    """
+    if conf:
+        try:
+            override_conf = config._process_config_file([conf])
+            config.conf.load_config(settings=override_conf)
+        except ValueError as e:
+            raise click.exceptions.BadParameter(e)
+
+
+from . import broker  # noqa

--- a/fedmsg/cli/broker.py
+++ b/fedmsg/cli/broker.py
@@ -1,0 +1,52 @@
+# This file is part of the fedmsg project
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""The Click command-line interface for the fedmsg broker."""
+from __future__ import absolute_import
+
+from gettext import gettext as _
+import logging
+import logging.config
+
+import click
+
+from fedmsg import config
+from fedmsg.broker.service import BrokerService
+from . import cli
+
+_log = logging.getLogger(__name__)
+
+_sub_help = _('The endpoint to use for message submission; defaults to the '
+              'fedmsg "submission_endpoint" configuration setting')
+
+
+@cli.command()
+@click.option('--submission-endpoint', '-s', help=_sub_help)
+def broker(submission_endpoint):
+    """
+    The fedmsg broker service.
+
+    This service is responsible for accepting messages from applications and publishing
+    them to the configured publication destinations.
+
+    Note: This service is experimental and may change without a major release.
+    """
+    logging.config.dictConfig(config.conf['logging'])
+
+    submission_endpoint = submission_endpoint or config.conf['submission_endpoint']
+
+    broker_service = BrokerService(submission_endpoint, config.conf['publishers'])
+    broker_service.start()

--- a/fedmsg/config.py
+++ b/fedmsg/config.py
@@ -47,6 +47,7 @@ import sys
 import textwrap
 import warnings
 
+import appdirs
 import six
 
 from kitchen.iterutils import iterate
@@ -180,6 +181,23 @@ class FedmsgConfig(dict):
     """
     _loaded = False
     _defaults = {
+        'submission_endpoint': {
+            'default': u'ipc://' + os.path.join(appdirs.user_data_dir('fedmsg', 'fedmsg'),
+                                                'submission.socket'),
+            'validator': _validate_none_or_type(six.text_type),
+        },
+        # A dictionary of publisher configuration dictionaries.
+        'publishers': {
+            'default': {
+                'zmq': {
+                    'publish_endpoint': 'tcp://*:9941'
+                },
+                'legacy_zmq': {
+                    'publish_endpoint': 'tcp://*:9940'
+                }
+            },
+            'validator': _validate_none_or_type(dict),
+        },
         'topic_prefix': {
             'default': u'com.example',
             'validator': _validate_none_or_type(six.text_type),

--- a/fedmsg/exceptions.py
+++ b/fedmsg/exceptions.py
@@ -1,0 +1,33 @@
+# This file is part of fedmsg.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""The exceptions raised by fedmsg."""
+
+
+class FedmsgException(Exception):
+    """The base fedmsg exception class."""
+
+
+class Timeout(FedmsgException, IOError):
+    """A timeout occurred."""
+
+
+class ReadTimeout(Timeout):
+    "A timeout occurred while trying to read from a ZeroMQ socket."""
+
+
+class WriteTimeout(Timeout):
+    "A timeout occurred while trying to write a message to a ZeroMQ socket."""

--- a/fedmsg/tests/broker/__init__.py
+++ b/fedmsg/tests/broker/__init__.py
@@ -1,0 +1,16 @@
+# This file is part of fedmsg.
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA

--- a/fedmsg/tests/broker/test_publishers.py
+++ b/fedmsg/tests/broker/test_publishers.py
@@ -1,0 +1,37 @@
+# This file is part of fedmsg.
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import unittest
+
+import zmq
+
+from fedmsg.broker import publishers
+
+
+class PublisherTests(unittest.TestCase):
+    """Unit tests for the :class:`fedmsg.broker.publishers.Publisher` class."""
+
+    def test_init(self):
+        """Assert initialization binds to an inproc socket."""
+        publisher = publishers.Publisher()
+
+        self.assertEqual(publisher.pair.socket_type, zmq.PAIR)
+        self.assertEqual('inproc://Publisher', publisher.pair_address)
+
+    def test_publish(self):
+        publisher = publishers.Publisher()
+        self.assertRaises(NotImplementedError, publisher.publish, None, None, None)

--- a/fedmsg/tests/broker/test_service.py
+++ b/fedmsg/tests/broker/test_service.py
@@ -1,0 +1,16 @@
+# This file is part of fedmsg.
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA

--- a/fedmsg/tests/test_config.py
+++ b/fedmsg/tests/test_config.py
@@ -21,6 +21,7 @@
 import os
 import unittest
 
+import appdirs
 import mock
 
 import fedmsg.config
@@ -127,6 +128,12 @@ class FedmsgConfigTests(unittest.TestCase):
     """Tests for :func:`fedmsg.config.FedmsgConfig`."""
 
     defaults = {
+        'submission_endpoint': 'ipc://' + os.path.join(
+            appdirs.user_data_dir('fedmsg', 'fedmsg'), 'submission.socket'),
+        'publishers': {
+            'zmq': {'publish_endpoint': u'tcp://*:9941'},
+            'legacy_zmq': {'publish_endpoint': u'tcp://*:9940'},
+        },
         'topic_prefix': 'com.example',
         'environment': 'dev',
         'io_threads': 1,

--- a/initsys/systemd/fedmsg-broker.service
+++ b/initsys/systemd/fedmsg-broker.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=The fedmsg broker
+After=network.target
+Documentation=https://fedmsg.readthedocs.org/
+
+[Service]
+ExecStart=/usr/bin/fedmsg broker
+Type=simple
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ long_description = long_description.split('split here', 1)[1]
 f.close()
 
 install_requires = [
+    'appdirs',
     'pyzmq',
     'kitchen',
     'requests',
@@ -174,6 +175,7 @@ setup(
             "fedmsg-signing-relay=fedmsg.commands.relay:signing_relay [consumers]",
             "fedmsg-gateway=fedmsg.commands.gateway:gateway [consumers]",
             "fedmsg-irc=fedmsg.commands.ircbot:ircbot [consumers]",
+            "fedmsg=fedmsg.cli:cli",
         ],
         'moksha.consumer': [
             "fedmsg-dummy=fedmsg.consumers.dummy:DummyConsumer [consumers]",


### PR DESCRIPTION
Hey folks,

This PR consists of two commits:

* Add a broker service that accepts message submissions and publishes them using "publishers".
* Add an API to publish via the broker

I'm interested in all feedback, but what I'm most interested in at the moment is feedback on the publish API. I wanted to get a feel for what people want before I start writing tests and tidying up the code.

To play with this, see the included documentation changes.

CC @ralphbean, @mikebonnet, @bowlofeggs, @pypingou, @abompard 
(I'm sure there are other interested parties I've forgotten about at the moment, sorry!)