### PR TITLE
Stop using ``ca_cert_cache`` in the consumer tests

### DIFF
--- a/fedmsg/tests/consumers/test_consumers.py
+++ b/fedmsg/tests/consumers/test_consumers.py
@@ -45,8 +45,8 @@ class FedmsgConsumerReplayTests(unittest.TestCase):
         self.config = {
             'dummy': True,
             'ssldir': SSLDIR,
-            'ca_cert_cache': os.path.join(SSLDIR, 'fedora_ca.crt'),
-            'ca_cert_cache_expiry': 1497618475,  # Stop fedmsg overwriting my CA, See Issue 420
+            'ca_cert_location': os.path.join(SSLDIR, 'fedora_ca.crt'),
+            'crl_location': None,
             'crypto_validate_backends': ['x509'],
         }
         self.hub = mock.Mock(config=self.config)


### PR DESCRIPTION
With the recent change to how CA certificates are loaded, just use the
path to certificate.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>