### PR TITLE
Feature: Remove dependency on config files

### DIFF
--- a/fedmsg/__init__.py
+++ b/fedmsg/__init__.py
@@ -53,10 +53,13 @@ def init(**kw):
         raise ValueError("fedmsg already initialized")
 
     # Read config from CLI args and a config file
-    config = fedmsg.config.load_config([], None)
+    config = fedmsg.config.conf
 
-    # Override the defaults with whatever the user explicitly passes in.
-    config.update(kw)
+    settings = {}
+    if kw:
+        settings['settings'] = kw
+
+    config.load_config(**settings)
 
     __local.__context = fedmsg.core.FedMsgContext(**config)
     return __local.__context

--- a/fedmsg/__init__.py
+++ b/fedmsg/__init__.py
@@ -54,12 +54,7 @@ def init(**kw):
 
     # Read config from CLI args and a config file
     config = fedmsg.config.conf
-
-    settings = {}
-    if kw:
-        settings['settings'] = kw
-
-    config.load_config(**settings)
+    config.load_config(kw)
 
     __local.__context = fedmsg.core.FedMsgContext(**config)
     return __local.__context


### PR DESCRIPTION
This allows a publisher to send a complete configuration via
`fedmsg.init()`.