### PR TITLE
Escape the backslash that escapes the dot

### DIFF
--- a/fedmsg/tests/fedmsg-test-config.py
+++ b/fedmsg/tests/fedmsg-test-config.py
@@ -41,7 +41,7 @@ gpg_key_main = 'FBDA 92E4 338D FFD9 EB83  F8F6 3FBD B725 DA19 B4EC'
 
 config = dict(
     topic_prefix="org.fedoraproject",
-    topic_prefix_re="^org\.fedoraproject\.(dev|stg|prod)",
+    topic_prefix_re="^org\\.fedoraproject\\.(dev|stg|prod)",
     endpoints={
         "unittest.%s" % hostname: [
             "tcp://*:%i" % (port + 1),


### PR DESCRIPTION
This will make python 3.6+ happier and stop sending DeprecationWarning

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>