### PR TITLE
handle messages with non-dict bodies

### DIFF
--- a/fedmsg/consumers/__init__.py
+++ b/fedmsg/consumers/__init__.py
@@ -252,7 +252,7 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
                 message['body'] = json.loads(message['body'].decode('utf-8'))
 
         # Massage STOMP messages into a more compatible format.
-        if 'topic' not in message['body']:
+        if not isinstance(message['body'], dict) or 'topic' not in message['body']:
             message['body'] = {
                 'topic': message.get('topic'),
                 'msg': message['body'],

--- a/fedmsg/tests/consumers/test_consumers.py
+++ b/fedmsg/tests/consumers/test_consumers.py
@@ -110,6 +110,22 @@ class FedmsgConsumerValidateTests(unittest.TestCase):
         self.consumer.validate(message)
         self.assertEqual({'body': {'topic': None, 'msg': {'some': 'stuff'}}}, message)
 
+    def test_none_body(self):
+        """Assert that a message body of None is replaced with an empty dict."""
+        self.consumer.validate_signatures = False
+        message = {'body': None}
+
+        self.consumer.validate(message)
+        self.assertEqual({'body': {'topic': None, 'msg': None}}, message)
+
+    def test_string_body(self):
+        """Assert that a message body that is a string is replaced with a dict."""
+        self.consumer.validate_signatures = False
+        message = {'body': 'this is the body'}
+
+        self.consumer.validate(message)
+        self.assertEqual({'body': {'topic': None, 'msg': 'this is the body'}}, message)
+
     @mock.patch('fedmsg.consumers.fedmsg.crypto.validate')
     def test_zmqmessage_text_body(self, mock_crypto_validate):
         self.consumer.validate_signatures = True


### PR DESCRIPTION
Lots of places in the fedmsg code assume that message['body'] is a dict. However,
it is possible for a producer to send a message with a body that is valid JSON
but does not encode a dict, which would cause validate() to fail. This change
ensures that message['body'] is always a dict.