### PR TITLE
always enable the MonitoringProducer

### DIFF
--- a/fedmsg.d/monitoring.py
+++ b/fedmsg.d/monitoring.py
@@ -1,0 +1,7 @@
+# Enable the MonitoringProducer.
+# Without this, consumers will leak memory.
+
+config = {
+    'moksha.monitoring.socket': 'ipc:///var/tmp/moksha-monitor',
+    'moksha.monitoring.socket.mode': '777',
+}

--- a/fedmsg/tests/test_commands.py
+++ b/fedmsg/tests/test_commands.py
@@ -341,8 +341,10 @@ class CheckTests(unittest.TestCase):
         thread = threading.Thread(target=report_in_thread)
         thread.start()
 
-    def test_no_monitor_endpoint(self):
+    @mock.patch('fedmsg.commands.check.load_config')
+    def test_no_monitor_endpoint(self, mock_load_config):
         """Assert that when no endpoint for monitoring is configured, users are informed."""
+        mock_load_config.return_value = {}
         expected_error = (
             u'Error: No monitoring endpoint has been configured: please set '
             u'"moksha.monitoring.socket"\n'


### PR DESCRIPTION
moksha records the time it takes a Consumer to process every message
in the Consumer._times list. The MonitoringProducer sends those times
to the monitor socket, and resets the list. If the MonitoringProducer
isn't running, that list grows forever, causing a memory leak. The
default configuration should always enable the MonitoringProducer.