### PR TITLE
Fix fedmsg-hub --with-consumers option

### DIFF
--- a/fedmsg/commands/hub.py
+++ b/fedmsg/commands/hub.py
@@ -72,7 +72,7 @@ class HubCommand(BaseCommand):
         consumers = None
         if self.config['explicit_hub_consumers']:
             locations = self.config['explicit_hub_consumers'].split(',')
-            locations = [load_class(location) for location in locations]
+            consumers = [load_class(location) for location in locations]
 
         # Rephrase the fedmsg-config.py config as moksha *.ini format for
         # zeromq. If we're not using zeromq (say, we're using STOMP), then just


### PR DESCRIPTION
Use explicit_hub_consumers list to build consumers list forwarded to
moksha.hub. Up until now, consumers list was always None.