### PR TITLE
Allow the maximum number of open files for fedmsg-hub to be configurable

### DIFF
--- a/fedmsg/commands/hub.py
+++ b/fedmsg/commands/hub.py
@@ -24,13 +24,6 @@ from fedmsg.utils import load_class
 from fedmsg.commands import BaseCommand
 
 
-# Since many services use fedmsg-hubs, processes can exceed their resource
-# limits on the number of open file descriptors. In the long term, apps should
-# stop listening to every service, but as a short term fix an attempt is made
-# to raise the resource limit here.
-MAX_NOFILE = 4096
-
-
 class HubCommand(BaseCommand):
     """ Run the fedmsg hub.
 
@@ -86,7 +79,7 @@ class HubCommand(BaseCommand):
             )
             self.config.update(moksha_options)
 
-        self.set_rlimit_nofiles()
+        self.set_rlimit_nofiles(self.config['max_open_files'])
 
         # Note that the hub we kick off here cannot send any message.  You
         # should use fedmsg.publish(...) still for that.
@@ -100,7 +93,7 @@ class HubCommand(BaseCommand):
             framework=False,
         )
 
-    def set_rlimit_nofiles(self, limit=MAX_NOFILE):
+    def set_rlimit_nofiles(self, limit):
         try:
             msg = _(u'Setting RLIMIT_NOFILE to '
                     u'{max_files}').format(max_files=limit)

--- a/fedmsg/config.py
+++ b/fedmsg/config.py
@@ -215,6 +215,15 @@ posted by :func:`fedmsg.commands.gateway.gateway`.  The
 :doc:`commands`.
 
 
+.. _conf-max_open_files:
+
+max_open_files
+--------------
+``int`` - The maximum number of open files that are allowed for the fedmsg-hub
+process.  This defaults to ``4096``.
+
+
+
 Authentication and Authorization
 ================================
 
@@ -1107,6 +1116,10 @@ class FedmsgConfig(dict):
             'default': None,
             'validator': _validate_none_or_type(six.text_type),
         },
+        'max_open_files': {
+            'default': 4096,
+            'validator': _validate_non_negative_int,
+        }
     }
 
     def __getitem__(self, *args, **kw):

--- a/fedmsg/tests/test_config.py
+++ b/fedmsg/tests/test_config.py
@@ -199,6 +199,7 @@ class FedmsgConfigTests(unittest.TestCase):
         'irc_method': 'notice',
         'active': False,
         'persistent_store': None,
+        'max_open_files': 4096,
         'logging': {
             'version': 1,
             'formatters': {


### PR DESCRIPTION
fedmsg-hub hard-coded a maximum number of open files to 4096. This
was unexpected behavior when the limit was raised in the systemd
configuration but the limit of 4096 was still reached. This commit
allows the number of open files to be configurable while maintaining
backwards compatibility.