### PR TITLE
Fix compatiblity with Python 3.11+

### DIFF
--- a/fedmsg/__init__.py
+++ b/fedmsg/__init__.py
@@ -64,7 +64,7 @@ def init(**kw):
 
 def API_function(doc=None):
     def api_function(func):
-        scrub = inspect.getargspec(func).args
+        scrub = inspect.getfullargspec(func).args
 
         @functools.wraps(func)
         def _wrapper(*args, **kw):


### PR DESCRIPTION
AttributeError: module 'inspect' has no attribute 'getargspec'


See from https://docs.python.org/3.11/whatsnew/3.11.html#removed

Removed from the inspect module:

> the getargspec function, deprecated since Python 3.0; use inspect.signature() or inspect.getfullargspec() instead.

Downstream bug report: https://bugzilla.redhat.com/show_bug.cgi?id=2095027