### PR TITLE
replace usage of inspect.getargspec() which was removed in Python 3.11

### DIFF
--- a/fedmsg/__init__.py
+++ b/fedmsg/__init__.py
@@ -64,7 +64,7 @@ def init(**kw):
 
 def API_function(doc=None):
     def api_function(func):
-        scrub = inspect.getargspec(func).args
+        scrub = inspect.getfullargspec(func).args
 
         @functools.wraps(func)
         def _wrapper(*args, **kw):


### PR DESCRIPTION
`getargspec()` has been deprecated since Python 3.0. `getfullargspec()` provides a compatible API.