### PR TITLE
Fix the Invalid argument error

### DIFF
--- a/fedmsg/consumers/gateway.py
+++ b/fedmsg/consumers/gateway.py
@@ -57,7 +57,7 @@ class GatewayConsumer(FedmsgConsumer):
         # we can serve.  To be effective, also increase nofile for fedmsg in
         # /etc/security/limits.conf to near fs.file-limit.  Try 160000.
         hwm = self.hub.config['fedmsg.consumers.gateway.high_water_mark']
-        if hasattr(zmq, 'HWM'):
+        if zmq.zmq_version().startswith("2."):
             # zeromq2
             self.gateway_socket.setsockopt(zmq.HWM, hwm)
         else:


### PR DESCRIPTION
This change will fix the error happening with zmq >= 23. `hasattr` still returned true even if the `HWM` can't be used anymore in zeromq 3+. This will rather check, if the version string for zeromq starts with `2.` More details about this issue could be found in https://pagure.io/fedora-infrastructure/issue/11023