### PR TITLE
Add configuration for skipping last message

### DIFF
--- a/fedmsg/config.py
+++ b/fedmsg/config.py
@@ -91,6 +91,14 @@ https://apps.fedoraproject.org/datagrepper/raw.  Can be used in conjunction with
 startup.
 
 
+.. _conf-skip_last_message:
+
+skip_last_message
+-----------------
+Upon restart skip the message that we worked on previously.
+This is an attempt to have the processing of the queue resume at
+the expense of droppin a message and possibly not awarding a badge.
+
 .. _conf-endpoints:
 
 endpoints
@@ -1106,6 +1114,10 @@ class FedmsgConfig(dict):
         'datagrepper_url': {
             'default': None,
             'validator': _validate_none_or_type(six.text_type),
+        },
+        'skip_last_message': {
+            'default': None,
+            'validator': _validate_bool,
         },
     }
 

--- a/fedmsg/consumers/__init__.py
+++ b/fedmsg/consumers/__init__.py
@@ -141,6 +141,7 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
                 os.makedirs(topmost_directory)
 
         self.datagrepper_url = self.hub.config.get('datagrepper_url')
+        self.skip_last_message = self.hub.config.get('skip_last_message')
         if self.status_filename and self.datagrepper_url:
             # First, try to read in the status from a previous run and fire off
             # a thread to set up our workload.
@@ -190,7 +191,10 @@ class FedmsgConsumer(moksha.hub.api.consumer.Consumer):
 
             if message['msg_id'] != last['msg_id']:
                 retrieved = retrieved + 1
-                self.incoming.put(dict(body=message, topic=message['topic']))
+                if (self.skip_last_message and retrieved <= 1):
+                    self.log.info("Skipping %r (as requested by skip_last_message)" % last['msg_id'])
+                else:
+                    self.incoming.put(dict(body=message, topic=message['topic']))
             else:
                 self.log.warning("Already seen %r; Skipping." % last['msg_id'])
 


### PR DESCRIPTION
This adds 'skip_last_message' config option, which will skip the message fedmsg-hub worked on last upon retrieval of the queue from datagrepper.

The idea is to have the processing advance at the expense of 'losing' a badge.