### PR TITLE
Remove mock as a dependency for Python 3

### DIFF
--- a/fedmsg/tests/commands/test_relay.py
+++ b/fedmsg/tests/commands/test_relay.py
@@ -23,7 +23,11 @@ from __future__ import absolute_import
 import unittest
 
 from moksha.hub import monitoring
-import mock
+# In Python 3 the mock is part of unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 from fedmsg.commands import relay
 

--- a/fedmsg/tests/consumers/test_consumers.py
+++ b/fedmsg/tests/consumers/test_consumers.py
@@ -25,7 +25,11 @@ import os
 import unittest
 
 from moksha.hub.zeromq.zeromq import ZMQMessage
-import mock
+# In Python 3 the mock is part of unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 from fedmsg import crypto
 from fedmsg.consumers import FedmsgConsumer

--- a/fedmsg/tests/consumers/test_irc.py
+++ b/fedmsg/tests/consumers/test_irc.py
@@ -1,6 +1,10 @@
 import unittest
 
-import mock
+# In Python 3 the mock is part of unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 from fedmsg.consumers import ircbot
 

--- a/fedmsg/tests/consumers/test_relay.py
+++ b/fedmsg/tests/consumers/test_relay.py
@@ -1,7 +1,11 @@
 import os
 import unittest
 
-import mock
+# In Python 3 the mock is part of unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 from fedmsg.consumers import relay
 

--- a/fedmsg/tests/crypto/test_utils.py
+++ b/fedmsg/tests/crypto/test_utils.py
@@ -3,7 +3,11 @@ import shutil
 import tempfile
 import unittest
 
-import mock
+# In Python 3 the mock is part of unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 from fedmsg.crypto import utils
 from fedmsg.tests import base

--- a/fedmsg/tests/crypto/test_x509.py
+++ b/fedmsg/tests/crypto/test_x509.py
@@ -21,7 +21,11 @@
 # Authors:  Jeremy Cline <jcline@redhat.com>
 import os
 
-import mock
+# In Python 3 the mock is part of unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 import six
 
 try:

--- a/fedmsg/tests/test_commands.py
+++ b/fedmsg/tests/test_commands.py
@@ -27,7 +27,11 @@ import unittest
 import time
 import json
 import os
-import mock
+# In Python 3 the mock is part of unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 from click.testing import CliRunner
 import six

--- a/fedmsg/tests/test_config.py
+++ b/fedmsg/tests/test_config.py
@@ -21,7 +21,11 @@
 import os
 import unittest
 
-import mock
+# In Python 3 the mock is part of unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 import fedmsg.config
 from fedmsg.tests.base import FIXTURES_DIR

--- a/fedmsg/tests/test_core.py
+++ b/fedmsg/tests/test_core.py
@@ -1,5 +1,9 @@
 import unittest
-import mock
+# In Python 3 the mock is part of unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 import warnings
 
 from fedmsg.core import FedMsgContext

--- a/fedmsg/tests/test_replay.py
+++ b/fedmsg/tests/test_replay.py
@@ -24,7 +24,11 @@ try:
 except ImportError:
     import unittest
 
-import mock
+# In Python 3 the mock is part of unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 import json
 from datetime import datetime
 import zmq

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,6 @@ moksha.hub
 pygments
 psutil
 sqlalchemy
-mock
 vcrpy
 flake8
 click


### PR DESCRIPTION
The mock library is available from unittest in Python 3 and will be soon deprecated in Fedora, so let's keep it only when it's needed.